### PR TITLE
Add the MIT license to all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 homepage = "https://github.com/rust-av/rust-av"
 keywords = ["multimedia"]
-license = "LGPL-2.1"
+license = "MIT"
 
 [features]
 nightly = []

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -3,6 +3,7 @@ name = "av-codec"
 description = "Multimedia format decoding and encoding"
 version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
+license = "MIT"
 
 [dependencies]
 num-rational = "0.1"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -3,6 +3,7 @@ name = "av-data"
 description = "Multimedia data structures"
 version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
+license = "MIT"
 
 [dependencies]
 failure = "0.1.1"

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -3,6 +3,7 @@ name = "av-format"
 description = "Multimedia format demuxing and muxing"
 version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
+license = "MIT"
 
 [dependencies]
 failure = "0.1.1"


### PR DESCRIPTION
Recently the project got relicensed under the MIT license.
Add license = "MIT" to the Cargo.toml to make the license clear.