### PR TITLE
Fix nightly regressions

### DIFF
--- a/bitstream/src/lib.rs
+++ b/bitstream/src/lib.rs
@@ -1,5 +1,5 @@
 // workarounds
-#![allow(unused_doc_comment)]
+#![allow(unused_doc_comments)]
 
 #[macro_use]
 extern crate failure;

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -1,5 +1,5 @@
 // workarounds
-#![allow(unused_doc_comment)]
+#![allow(unused_doc_comments)]
 
 // language extensions
 #![feature(box_syntax, plugin)]

--- a/data/src/frame.rs
+++ b/data/src/frame.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, unused_variables)]
-use alloc::heap::{Global, Alloc, Layout};
+use alloc::alloc::{Global, Alloc, Layout};
 use bytes::BytesMut;
 
 use std::sync::Arc;

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,5 +1,5 @@
 // workarounds
-#![allow(unused_doc_comment)]
+#![allow(unused_doc_comments)]
 
 // language extensions
 #![feature(box_syntax, plugin, allocator_api, alloc)]

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,5 +1,5 @@
 // workarounds
-#![allow(unused_doc_comment)]
+#![allow(unused_doc_comments)]
 
 // crates
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // workarounds
-#![allow(unused_doc_comment)]
+#![allow(unused_doc_comments)]
 
 // language extensions
 #![feature(box_syntax, plugin)]


### PR DESCRIPTION
- lint "unused_doc_comment" has been renamed to "unused_doc_comments"
- alloc::heap has been partially moved to alloc::alloc