### PR TITLE
Add continuous integration on Windows with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Build Status](https://travis-ci.org/rust-av/rust-av.svg?branch=master)](https://travis-ci.org/rust-av/rust-av)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/xiph/rav1e?branch=master&svg=true)](https://ci.appveyor.com/project/xiph/rav1e)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/rust-av/rust-av?branch=master&svg=true)](https://ci.appveyor.com/project/rust-av/rust-av)
 [![Coverage Status](https://coveralls.io/repos/rust-av/rust-av/badge.svg?branch=master)](https://coveralls.io/r/rust-av/rust-av?branch=master)
 [![dependency status](https://deps.rs/repo/github/rust-av/rust-av/status.svg)](https://deps.rs/repo/github/rust-av/rust-av)
 [![IRC](https://img.shields.io/badge/irc-%23rust--av-blue.svg)](http://webchat.freenode.net?channels=%23rust-av&uio=d4)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Build Status](https://travis-ci.org/rust-av/rust-av.svg?branch=master)](https://travis-ci.org/rust-av/rust-av)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/rust-av/rust-av?branch=master&svg=true)](https://ci.appveyor.com/project/rust-av/rust-av)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/rust-av/rust-av?branch=master&svg=true)](https://ci.appveyor.com/project/lu-zero/rust-av/history)
 [![Coverage Status](https://coveralls.io/repos/rust-av/rust-av/badge.svg?branch=master)](https://coveralls.io/r/rust-av/rust-av?branch=master)
 [![dependency status](https://deps.rs/repo/github/rust-av/rust-av/status.svg)](https://deps.rs/repo/github/rust-av/rust-av)
 [![IRC](https://img.shields.io/badge/irc-%23rust--av-blue.svg)](http://webchat.freenode.net?channels=%23rust-av&uio=d4)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Build Status](https://travis-ci.org/rust-av/rust-av.svg?branch=master)](https://travis-ci.org/rust-av/rust-av)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/xiph/rav1e?branch=master&svg=true)](https://ci.appveyor.com/project/xiph/rav1e)
 [![Coverage Status](https://coveralls.io/repos/rust-av/rust-av/badge.svg?branch=master)](https://coveralls.io/r/rust-av/rust-av?branch=master)
 [![dependency status](https://deps.rs/repo/github/rust-av/rust-av/status.svg)](https://deps.rs/repo/github/rust-av/rust-av)
 [![IRC](https://img.shields.io/badge/irc-%23rust--av-blue.svg)](http://webchat.freenode.net?channels=%23rust-av&uio=d4)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,15 @@ environment:
     - platform: x86_64
       target: x86_64-pc-windows-msvc
       channel: stable
+    - platform: x86_64
+      target: x86_64-pc-windows-msvc
+      channel: stable
     - platform: arm64
       target: aarch64-pc-windows-msvc
       channel: nightly
 matrix:
   allow_failures:
+    - platform: stable
     - platform: arm64
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,5 +34,5 @@ test_script:
     - cargo test --target=%target% --verbose
 
 artifacts:
-    - path: target\$(target)\release\rust-av*.*
+    - path: target\$(target)\release\*.*
       name: rust-av-$(platform)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+image: Visual Studio 2017
+
+environment:
+  host: x86_64-pc-windows-msvc
+  matrix:
+    - platform: x86_64
+      target: x86_64-pc-windows-msvc
+      channel: stable
+    - platform: arm64
+      target: aarch64-pc-windows-msvc
+      channel: nightly
+matrix:
+  allow_failures:
+    - platform: arm64
+
+install:
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+    - rustup-init -yv --default-toolchain %channel% --default-host %host%
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
+    - ps: $Env:PKG_CONFIG_ALLOW_CROSS=1
+    - rustc -vV
+    - cargo -vV
+    - rustup target add %target%
+    - git submodule update --init
+
+build_script:
+    - cargo build --release --target=%target%
+
+test_script:
+    - cargo test --target=%target% --verbose
+
+artifacts:
+    - path: target\$(target)\release\rust-av*.*
+      name: rust-av-$(platform)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   matrix:
     - platform: x86_64
       target: x86_64-pc-windows-msvc
-      channel: stable
+      channel: nightly
     - platform: x86_64
       target: x86_64-pc-windows-msvc
       channel: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
       channel: nightly
 matrix:
   allow_failures:
-    - platform: stable
+    - channel: stable
     - platform: arm64
 
 install:


### PR DESCRIPTION
Was relatively easy, so here's AppVeyor config. AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) in the GitHub Marketplace.

`x86_64-pc-windows-msvc` on Rust `stable` fails because `rust_2018_preview` is used.
```
   Compiling av-codec v0.1.0 (C:\projects\rust-av\codec)
error[E0554]: #![feature] may not be used on the stable release channel
 --> codec\src\lib.rs:5:1
  |
5 | #![feature(box_syntax, plugin, rust_2018_preview)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
error: aborting due to previous error
```
`aarch64-pc-windows-msvc` fails because [winapi-rs](https://github.com/retep998/winapi-rs) can't deal with aarch64 targets (see https://github.com/retep998/winapi-rs/issues/727 and https://github.com/retep998/winapi-rs/issues/728).

For now they are both allowed failures.

Wat is fustration though is this behaviour on the aarch64 build:
```
error: Could not compile `winapi`.
warning: build failed, waiting for other jobs to finish...
```
And then it doesn't stop until it times out in an hour.