### PR TITLE
Update to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ license = "MIT"
 nightly = []
 
 [dependencies.av-data]
-path = "data"
-version = "*"
+version = "0.1.0"
 
 [dependencies.av-format]
 path = "format"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 homepage = "https://github.com/rust-av/rust-av"
 keywords = ["multimedia"]
 license = "MIT"
+edition = "2018"
 
 [features]
 nightly = []

--- a/bitstream/Cargo.toml
+++ b/bitstream/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 repository = "https://github.com/rust-av/rust-av"
+edition = "2018"
 
 [dependencies]
 failure = "0.1.5"

--- a/bitstream/Cargo.toml
+++ b/bitstream/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 repository = "https://github.com/rust-av/rust-av"
 
 [dependencies]
-failure = "0.1"
-num-traits = "0.2"
+failure = "0.1.5"
+num-traits = "0.2.8"
 
 [dev-dependencies]
-assert_matches = "1.1"
+assert_matches = "1.3.0"

--- a/bitstream/src/bitread.rs
+++ b/bitstream/src/bitread.rs
@@ -1,10 +1,10 @@
 use crate::byteread::*;
 
 pub trait BitReadEndian {
-    fn peek_val(&mut self, n:usize) -> u64;
-    fn merge_val(msp:u64, lsp:u64, msb:usize, lsb:usize) -> u64;
-    fn build_cache(cache:u64, refill:u64, cache_size:usize) -> u64;
-    fn skip_rem(&mut self, n:usize) -> ();
+    fn peek_val(&mut self, n: usize) -> u64;
+    fn merge_val(msp: u64, lsp: u64, msb: usize, lsb: usize) -> u64;
+    fn build_cache(cache: u64, refill: u64, cache_size: usize) -> u64;
+    fn skip_rem(&mut self, n: usize) -> ();
 }
 
 pub trait BitReadFill {
@@ -13,27 +13,26 @@ pub trait BitReadFill {
     fn fill64(&self) -> u64;
 }
 
-pub trait BitReadInternal : BitReadEndian + BitReadFill {
+pub trait BitReadInternal: BitReadEndian + BitReadFill {
     fn left(&self) -> usize;
     fn refill32(&mut self) -> ();
     fn refill64(&mut self) -> ();
 
-    fn get_val(&mut self, n:usize) -> u64 {
+    fn get_val(&mut self, n: usize) -> u64 {
         let ret = self.peek_val(n);
 
         self.skip_rem(n);
 
         ret
     }
-
 }
 
-pub trait BitRead<'a>: BitReadInternal+Copy {
-    fn new(_: &'a[u8]) -> Self;
+pub trait BitRead<'a>: BitReadInternal + Copy {
+    fn new(_: &'a [u8]) -> Self;
     fn consumed(&self) -> usize;
     fn available(&self) -> usize;
 
-    fn skip_bits(&mut self, size : usize) -> ();
+    fn skip_bits(&mut self, size: usize) -> ();
 
     #[inline]
     fn get_bit(&mut self) -> bool {
@@ -45,7 +44,7 @@ pub trait BitRead<'a>: BitReadInternal+Copy {
     }
 
     #[inline]
-    fn get_bits_64(&mut self, mut n:usize) -> u64 {
+    fn get_bits_64(&mut self, mut n: usize) -> u64 {
         let mut left = 0;
         let mut ret = 0;
 
@@ -54,9 +53,9 @@ pub trait BitRead<'a>: BitReadInternal+Copy {
         }
 
         if self.left() < n {
-            n   -= self.left();
+            n -= self.left();
             left = self.left();
-            ret  = self.get_val(left);
+            ret = self.get_val(left);
             self.refill64();
         }
 
@@ -64,7 +63,7 @@ pub trait BitRead<'a>: BitReadInternal+Copy {
     }
 
     #[inline]
-    fn get_bits_32(&mut self, n:usize) -> u32 {
+    fn get_bits_32(&mut self, n: usize) -> u32 {
         if n == 0 {
             return 0;
         }
@@ -76,7 +75,6 @@ pub trait BitRead<'a>: BitReadInternal+Copy {
         self.get_val(n) as u32
     }
 
-
     #[inline]
     fn peek_bit(&mut self) -> bool {
         let mut tmp = *self;
@@ -85,14 +83,14 @@ pub trait BitRead<'a>: BitReadInternal+Copy {
     }
 
     #[inline]
-    fn peek_bits_32(&mut self, n:usize) -> u32 {
+    fn peek_bits_32(&mut self, n: usize) -> u32 {
         let mut tmp = *self;
 
         tmp.get_bits_32(n)
     }
 
     #[inline]
-    fn peek_bits_64(&self, n:usize) -> u64 {
+    fn peek_bits_64(&self, n: usize) -> u64 {
         let mut tmp = *self;
 
         tmp.get_bits_64(n)
@@ -217,9 +215,9 @@ macro_rules! little_endian_reader {
     }
 }
 
-little_endian_reader!{ BitReadLE }
+little_endian_reader! { BitReadLE }
 
-impl <'a> BitReadFill for BitReadLE<'a> {
+impl<'a> BitReadFill for BitReadLE<'a> {
     #[inline]
     fn can_refill(&self) -> bool {
         self.index + 8 <= self.buffer.len()
@@ -261,9 +259,9 @@ macro_rules! big_endian_reader {
     }
 }
 
-big_endian_reader!{ BitReadBE }
+big_endian_reader! { BitReadBE }
 
-impl <'a> BitReadFill for BitReadBE<'a> {
+impl<'a> BitReadFill for BitReadBE<'a> {
     #[inline]
     fn can_refill(&self) -> bool {
         self.index + 8 <= self.buffer.len()
@@ -277,7 +275,6 @@ impl <'a> BitReadFill for BitReadBE<'a> {
         get_u64b(&self.buffer[self.index..])
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -316,7 +313,7 @@ mod test {
                 buffer: &CHECKBOARD0101,
                 index: 0,
                 cache: 0,
-                left: 0
+                left: 0,
             };
 
             assert!(reader.peek_bits_64(1) == 1);
@@ -331,7 +328,7 @@ mod test {
                 buffer: &CHECKBOARD0101,
                 index: 0,
                 cache: 0,
-                left: 0
+                left: 0,
             };
 
             assert!(reader.get_bits_32(1) == 1);
@@ -389,7 +386,7 @@ mod test {
             let b = &CHECKBOARD0011;
             let mut reader = BitReadLE::new(b);
 
-            reader.skip_bits(128*8+2);
+            reader.skip_bits(128 * 8 + 2);
             reader.get_bits_64(6);
         }
     }
@@ -490,7 +487,7 @@ mod test {
             let b = &CHECKBOARD0011;
             let mut reader = BitReadBE::new(b);
 
-            reader.skip_bits(128*8+2);
+            reader.skip_bits(128 * 8 + 2);
             reader.get_bits_64(6);
         }
     }

--- a/bitstream/src/bitread.rs
+++ b/bitstream/src/bitread.rs
@@ -1,4 +1,4 @@
-use byteread::*;
+use crate::byteread::*;
 
 pub trait BitReadEndian {
     fn peek_val(&mut self, n:usize) -> u64;
@@ -29,7 +29,7 @@ pub trait BitReadInternal : BitReadEndian + BitReadFill {
 }
 
 pub trait BitRead<'a>: BitReadInternal+Copy {
-    fn new(&'a[u8]) -> Self;
+    fn new(_: &'a[u8]) -> Self;
     fn consumed(&self) -> usize;
     fn available(&self) -> usize;
 

--- a/bitstream/src/byteread.rs
+++ b/bitstream/src/byteread.rs
@@ -9,103 +9,101 @@ use std::ptr;
 // TODO: aligned/non-aligned version
 
 macro_rules! read_num_bytes {
-    ($ty:ty, $size:expr, $src:expr, $which:ident) => ({
+    ($ty:ty, $size:expr, $src:expr, $which:ident) => {{
         let mut data: $ty = 0;
         unsafe {
-            ptr::copy_nonoverlapping($src.as_ptr(),
-                &mut data as *mut $ty as *mut u8,
-                $size);
+            ptr::copy_nonoverlapping($src.as_ptr(), &mut data as *mut $ty as *mut u8, $size);
         }
         data.$which()
-    });
+    }};
 }
 
 #[inline]
-pub fn get_u8(buf:&[u8]) -> u8 {
+pub fn get_u8(buf: &[u8]) -> u8 {
     buf[0] as u8
 }
 
 #[inline]
-pub fn get_i8(buf:&[u8]) -> i8 {
+pub fn get_i8(buf: &[u8]) -> i8 {
     buf[0] as i8
 }
 
 #[inline]
-pub fn get_u16l(buf:&[u8]) -> u16 {
+pub fn get_u16l(buf: &[u8]) -> u16 {
     read_num_bytes!(u16, 2, buf, to_le)
 }
 
 #[inline]
-pub fn get_u16b(buf:&[u8]) -> u16 {
+pub fn get_u16b(buf: &[u8]) -> u16 {
     read_num_bytes!(u16, 2, buf, to_be)
 }
 
 #[inline]
-pub fn get_u32l(buf:&[u8]) -> u32 {
+pub fn get_u32l(buf: &[u8]) -> u32 {
     read_num_bytes!(u32, 4, buf, to_le)
 }
 
 #[inline]
-pub fn get_u32b(buf:&[u8]) -> u32 {
+pub fn get_u32b(buf: &[u8]) -> u32 {
     read_num_bytes!(u32, 4, buf, to_be)
 }
 
 #[inline]
-pub fn get_u64l(buf:&[u8]) -> u64 {
+pub fn get_u64l(buf: &[u8]) -> u64 {
     read_num_bytes!(u64, 8, buf, to_le)
 }
 
 #[inline]
-pub fn get_u64b(buf:&[u8]) -> u64 {
+pub fn get_u64b(buf: &[u8]) -> u64 {
     read_num_bytes!(u64, 8, buf, to_be)
 }
 
 #[inline]
-pub fn get_i16l(buf:&[u8]) -> i16 {
+pub fn get_i16l(buf: &[u8]) -> i16 {
     get_u16l(buf) as i16
 }
 
 #[inline]
-pub fn get_i16b(buf:&[u8]) -> i16 {
+pub fn get_i16b(buf: &[u8]) -> i16 {
     get_u16b(buf) as i16
 }
 
 #[inline]
-pub fn get_i32l(buf:&[u8]) -> i32 {
+pub fn get_i32l(buf: &[u8]) -> i32 {
     get_u32l(buf) as i32
 }
 
 #[inline]
-pub fn get_i32b(buf:&[u8]) -> i32 {
+pub fn get_i32b(buf: &[u8]) -> i32 {
     get_u32b(buf) as i32
 }
 
 #[inline]
-pub fn get_i64l(buf:&[u8]) -> i64 {
+pub fn get_i64l(buf: &[u8]) -> i64 {
     get_u64l(buf) as i64
 }
 
 #[inline]
-pub fn get_i64b(buf:&[u8]) -> i64 {
+pub fn get_i64b(buf: &[u8]) -> i64 {
     get_u64b(buf) as i64
 }
 
 #[inline]
-pub fn get_f32l(buf:&[u8]) -> f32 {
+pub fn get_f32l(buf: &[u8]) -> f32 {
     f32::from_bits(get_u32l(buf))
 }
 
 #[inline]
-pub fn get_f32b(buf:&[u8]) -> f32 {
+pub fn get_f32b(buf: &[u8]) -> f32 {
     f32::from_bits(get_u32b(buf))
 }
 
 #[inline]
-pub fn get_f64l(buf:&[u8]) -> f64 {
+pub fn get_f64l(buf: &[u8]) -> f64 {
     f64::from_bits(get_u64l(buf))
 }
 
 #[inline]
-pub fn get_f64b(buf:&[u8]) -> f64 {
+pub fn get_f64b(buf: &[u8]) -> f64 {
     f64::from_bits(get_u64b(buf))
 }

--- a/bitstream/src/bytewrite.rs
+++ b/bitstream/src/bytewrite.rs
@@ -108,7 +108,7 @@ pub fn put_f64b(buf:&mut[u8], n:f64) {
 mod test {
 
     use super::*;
-    use byteread::*;
+    use crate::byteread::*;
 
     #[test]
     fn put_and_get_u8() {

--- a/bitstream/src/bytewrite.rs
+++ b/bitstream/src/bytewrite.rs
@@ -4,103 +4,103 @@ use std::mem::transmute;
 use std::ptr::copy_nonoverlapping;
 
 macro_rules! write_num_bytes {
-    ($ty:ty, $size:expr, $dst:expr, $n:expr, $which:ident) => ({
+    ($ty:ty, $size:expr, $dst:expr, $n:expr, $which:ident) => {{
         assert!($size <= $dst.len());
         unsafe {
             // N.B. https://github.com/rust-lang/rust/issues/22776
             let bytes = transmute::<_, [u8; $size]>($n.$which());
             copy_nonoverlapping((&bytes).as_ptr(), $dst.as_mut_ptr(), $size);
         }
-    })
+    }};
 }
 
 #[inline]
-pub fn put_u8(buf:&mut[u8], n:u8) {
+pub fn put_u8(buf: &mut [u8], n: u8) {
     buf[0] = n;
 }
 
 #[inline]
-pub fn put_i8(buf:&mut[u8], n:i8) {
+pub fn put_i8(buf: &mut [u8], n: i8) {
     buf[0] = n as u8;
 }
 
 #[inline]
-pub fn put_u16l(buf:&mut[u8], n:u16) {
+pub fn put_u16l(buf: &mut [u8], n: u16) {
     write_num_bytes!(u16, 2, buf, n, to_le);
 }
 
 #[inline]
-pub fn put_u16b(buf:&mut[u8], n:u16) {
+pub fn put_u16b(buf: &mut [u8], n: u16) {
     write_num_bytes!(u16, 2, buf, n, to_be);
 }
 
 #[inline]
-pub fn put_u32l(buf:&mut[u8], n:u32) {
+pub fn put_u32l(buf: &mut [u8], n: u32) {
     write_num_bytes!(u32, 4, buf, n, to_le);
 }
 
 #[inline]
-pub fn put_u32b(buf:&mut[u8], n:u32) {
+pub fn put_u32b(buf: &mut [u8], n: u32) {
     write_num_bytes!(u32, 4, buf, n, to_be);
 }
 
 #[inline]
-pub fn put_u64l(buf:&mut[u8], n:u64) {
+pub fn put_u64l(buf: &mut [u8], n: u64) {
     write_num_bytes!(u64, 8, buf, n, to_le);
 }
 
 #[inline]
-pub fn put_u64b(buf:&mut[u8], n:u64) {
+pub fn put_u64b(buf: &mut [u8], n: u64) {
     write_num_bytes!(u64, 8, buf, n, to_be);
 }
 
 #[inline]
-pub fn put_i16l(buf:&mut[u8], n:i16) {
+pub fn put_i16l(buf: &mut [u8], n: i16) {
     put_u16l(buf, n as u16);
 }
 
 #[inline]
-pub fn put_i16b(buf:&mut[u8], n:i16) {
+pub fn put_i16b(buf: &mut [u8], n: i16) {
     put_u16b(buf, n as u16);
 }
 
 #[inline]
-pub fn put_i32l(buf:&mut[u8], n:i32) {
+pub fn put_i32l(buf: &mut [u8], n: i32) {
     put_u32l(buf, n as u32);
 }
 
 #[inline]
-pub fn put_i32b(buf:&mut[u8], n:i32) {
+pub fn put_i32b(buf: &mut [u8], n: i32) {
     put_u32b(buf, n as u32);
 }
 
 #[inline]
-pub fn put_i64l(buf:&mut[u8], n:i64) {
+pub fn put_i64l(buf: &mut [u8], n: i64) {
     put_u64l(buf, n as u64);
 }
 
 #[inline]
-pub fn put_i64b(buf:&mut[u8], n:i64) {
+pub fn put_i64b(buf: &mut [u8], n: i64) {
     put_u64b(buf, n as u64);
 }
 
 #[inline]
-pub fn put_f32l(buf:&mut[u8], n:f32) {
+pub fn put_f32l(buf: &mut [u8], n: f32) {
     put_u32l(buf, unsafe { transmute(n) });
 }
 
 #[inline]
-pub fn put_f32b(buf:&mut[u8], n:f32) {
+pub fn put_f32b(buf: &mut [u8], n: f32) {
     put_u32b(buf, unsafe { transmute(n) });
 }
 
 #[inline]
-pub fn put_f64l(buf:&mut[u8], n:f64) {
+pub fn put_f64l(buf: &mut [u8], n: f64) {
     put_u64l(buf, unsafe { transmute(n) });
 }
 
 #[inline]
-pub fn put_f64b(buf:&mut[u8], n:f64) {
+pub fn put_f64b(buf: &mut [u8], n: f64) {
     put_u64b(buf, unsafe { transmute(n) });
 }
 

--- a/bitstream/src/codebook.rs
+++ b/bitstream/src/codebook.rs
@@ -1,4 +1,4 @@
-use bitread::*;
+use crate::bitread::*;
 use std::collections::HashMap;
 use std::cmp::{min, max};
 use std::marker::PhantomData;

--- a/bitstream/src/codebook.rs
+++ b/bitstream/src/codebook.rs
@@ -1,15 +1,15 @@
 use crate::bitread::*;
-use std::collections::HashMap;
-use std::cmp::{min, max};
-use std::marker::PhantomData;
 use num_traits::AsPrimitive;
+use std::cmp::{max, min};
+use std::collections::HashMap;
+use std::marker::PhantomData;
 
 #[derive(Fail, Debug)]
 pub enum CodebookError {
     #[fail(display = "Invalid Codebook")]
     InvalidCodebook,
     #[fail(display = "Invalid Code")]
-    InvalidCode
+    InvalidCode,
 }
 
 use self::CodebookError::*;
@@ -52,8 +52,10 @@ pub trait CodebookReader<S> {
 }
 
 pub fn reverse_bits(inval: u32) -> u32 {
-    const REV_TAB: [u8; 16] = [0b0000, 0b1000, 0b0100, 0b1100, 0b0010, 0b1010, 0b0110, 0b1110,
-                               0b0001, 0b1001, 0b0101, 0b1101, 0b0011, 0b1011, 0b0111, 0b1111];
+    const REV_TAB: [u8; 16] = [
+        0b0000, 0b1000, 0b0100, 0b1100, 0b0010, 0b1010, 0b0110, 0b1110, 0b0001, 0b1001, 0b0101,
+        0b1101, 0b0011, 0b1011, 0b0111, 0b1111,
+    ];
 
     let mut ret = 0;
     let mut val = inval;
@@ -67,13 +69,15 @@ pub fn reverse_bits(inval: u32) -> u32 {
 const TABLE_FILL_VALUE: u32 = 0x7F;
 const MAX_LUT_BITS: u8 = 10;
 
-fn fill_lut_msb(table: &mut Vec<u32>,
-                off: usize,
-                code: u32,
-                bits: u8,
-                lut_bits: u8,
-                symidx: u32,
-                esc: bool) {
+fn fill_lut_msb(
+    table: &mut Vec<u32>,
+    off: usize,
+    code: u32,
+    bits: u8,
+    lut_bits: u8,
+    symidx: u32,
+    esc: bool,
+) {
     if !esc {
         let fill_len = lut_bits - bits;
         let fill_size = 1 << fill_len;
@@ -89,13 +93,15 @@ fn fill_lut_msb(table: &mut Vec<u32>,
     }
 }
 
-fn fill_lut_lsb(table: &mut Vec<u32>,
-                off: usize,
-                code: u32,
-                bits: u8,
-                lut_bits: u8,
-                symidx: u32,
-                esc: bool) {
+fn fill_lut_lsb(
+    table: &mut Vec<u32>,
+    off: usize,
+    code: u32,
+    bits: u8,
+    lut_bits: u8,
+    symidx: u32,
+    esc: bool,
+) {
     if !esc {
         let fill_len = lut_bits - bits;
         let fill_size = 1 << fill_len;
@@ -111,15 +117,16 @@ fn fill_lut_lsb(table: &mut Vec<u32>,
     }
 }
 
-fn fill_lut(table: &mut Vec<u32>,
-            mode: CodebookMode,
-            off: usize,
-            code: u32,
-            bits: u8,
-            lut_bits: u8,
-            symidx: u32,
-            esc: bool)
-            -> bool {
+fn fill_lut(
+    table: &mut Vec<u32>,
+    mode: CodebookMode,
+    off: usize,
+    code: u32,
+    bits: u8,
+    lut_bits: u8,
+    symidx: u32,
+    esc: bool,
+) -> bool {
     match mode {
         CodebookMode::MSB => fill_lut_msb(table, off, code, bits, lut_bits, symidx, esc),
         CodebookMode::LSB => fill_lut_lsb(table, off, code, bits, lut_bits, symidx, esc),
@@ -136,7 +143,6 @@ fn resize_table(table: &mut Vec<u32>, bits: u8) -> u32 {
     cur_off
 }
 
-
 fn extract_lut_part(code: u32, bits: u8, lut_bits: u8, mode: CodebookMode) -> u32 {
     match mode {
         CodebookMode::MSB => code >> (bits - lut_bits),
@@ -151,7 +157,7 @@ fn extract_esc_part(code: u32, bits: u8, lut_bits: u8, mode: CodebookMode) -> u3
     }
 }
 
-#[derive(Clone,Copy)]
+#[derive(Clone, Copy)]
 struct Code {
     code: u32,
     bits: u8,
@@ -184,28 +190,30 @@ type EscapeCodes = HashMap<u32, CodeBucket>;
 
 fn add_esc_code(cc: &mut EscapeCodes, key: u32, code: u32, bits: u8, idx: usize) {
     let bucket = cc.entry(key).or_insert_with(CodeBucket::new);
-    bucket.add_code(Code {
-        code,
-        bits,
-        idx,
-    });
+    bucket.add_code(Code { code, bits, idx });
 }
 
-fn build_esc_lut(table: &mut Vec<u32>, mode: CodebookMode, bucket: &CodeBucket) -> Result<(), CodebookError> {
+fn build_esc_lut(
+    table: &mut Vec<u32>,
+    mode: CodebookMode,
+    bucket: &CodeBucket,
+) -> Result<(), CodebookError> {
     let mut escape_list: EscapeCodes = HashMap::new();
     let maxlen = min(bucket.maxlen, MAX_LUT_BITS);
 
     for code in &bucket.codes {
         let bits = code.bits;
         if code.bits <= MAX_LUT_BITS {
-            fill_lut(table,
-                     mode,
-                     bucket.offset,
-                     code.code,
-                     bits,
-                     maxlen,
-                     code.idx as u32,
-                     false);
+            fill_lut(
+                table,
+                mode,
+                bucket.offset,
+                code.code,
+                bits,
+                maxlen,
+                code.idx as u32,
+                false,
+            );
         } else {
             let ckey = extract_lut_part(code.code, bits, MAX_LUT_BITS, mode);
             let cval = extract_esc_part(code.code, bits, MAX_LUT_BITS, mode);
@@ -218,14 +226,16 @@ fn build_esc_lut(table: &mut Vec<u32>, mode: CodebookMode, bucket: &CodeBucket) 
         let key = *ckey as u32;
         let maxlen = min(sec_bucket.maxlen, MAX_LUT_BITS);
         let new_off = resize_table(table, maxlen);
-        fill_lut(table,
-                 mode,
-                 cur_offset,
-                 key,
-                 maxlen,
-                 MAX_LUT_BITS,
-                 new_off,
-                 true);
+        fill_lut(
+            table,
+            mode,
+            cur_offset,
+            key,
+            maxlen,
+            MAX_LUT_BITS,
+            new_off,
+            true,
+        );
         sec_bucket.offset = new_off as usize;
     }
 
@@ -237,7 +247,10 @@ fn build_esc_lut(table: &mut Vec<u32>, mode: CodebookMode, bucket: &CodeBucket) 
 }
 
 impl<S: Copy> Codebook<S> {
-    pub fn new(cb: &mut dyn CodebookDescReader<S>, mode: CodebookMode) -> Result<Self, CodebookError> {
+    pub fn new(
+        cb: &mut dyn CodebookDescReader<S>,
+        mode: CodebookMode,
+    ) -> Result<Self, CodebookError> {
         let mut maxbits = 0;
         let mut nnz = 0;
         let mut escape_list: EscapeCodes = HashMap::new();
@@ -288,14 +301,16 @@ impl<S: Copy> Codebook<S> {
                     if let Some(bucket) = escape_list.get_mut(&key) {
                         let maxlen = min(bucket.maxlen, MAX_LUT_BITS);
                         let new_off = resize_table(&mut table, maxlen);
-                        fill_lut(&mut table,
-                                 mode,
-                                 0,
-                                 key,
-                                 maxlen,
-                                 MAX_LUT_BITS,
-                                 new_off,
-                                 true);
+                        fill_lut(
+                            &mut table,
+                            mode,
+                            0,
+                            key,
+                            maxlen,
+                            MAX_LUT_BITS,
+                            new_off,
+                            true,
+                        );
                         bucket.offset = new_off as usize;
                     }
                 }
@@ -329,7 +344,6 @@ impl<'a, S: Copy, B: BitRead<'a>> CodebookReader<S> for B {
         while esc {
             let lut_idx = (self.peek_bits_32(lut_bits as usize) as usize) + (idx as usize);
             if cb.table[lut_idx] == TABLE_FILL_VALUE {
-
                 return Err(InvalidCode);
             }
             let bits = cb.table[lut_idx] & 0x7F;
@@ -423,26 +437,28 @@ mod test {
 
     #[test]
     fn test_full_codebook_msb() {
-        let mut cb_desc: Vec<FullCodebookDesc<i8>> = vec![FullCodebookDesc {
-                                                              code: 0b0,
-                                                              bits: 1,
-                                                              sym: 16,
-                                                          },
-                                                          FullCodebookDesc {
-                                                              code: 0b10,
-                                                              bits: 2,
-                                                              sym: -3,
-                                                          },
-                                                          FullCodebookDesc {
-                                                              code: 0b110,
-                                                              bits: 3,
-                                                              sym: 42,
-                                                          },
-                                                          FullCodebookDesc {
-                                                              code: 0b1110,
-                                                              bits: 4,
-                                                              sym: -42,
-                                                          }];
+        let mut cb_desc: Vec<FullCodebookDesc<i8>> = vec![
+            FullCodebookDesc {
+                code: 0b0,
+                bits: 1,
+                sym: 16,
+            },
+            FullCodebookDesc {
+                code: 0b10,
+                bits: 2,
+                sym: -3,
+            },
+            FullCodebookDesc {
+                code: 0b110,
+                bits: 3,
+                sym: 42,
+            },
+            FullCodebookDesc {
+                code: 0b1110,
+                bits: 4,
+                sym: -42,
+            },
+        ];
         let buf = &BITS;
         let mut br = BitReadBE::new(buf);
         let cb = Codebook::new(&mut cb_desc, CodebookMode::MSB).unwrap();
@@ -461,46 +477,45 @@ mod test {
 
     #[test]
     fn test_short_codebook_msb() {
-        let mut scb_desc: Vec<ShortCodebookDesc> = vec![ShortCodebookDesc {
-                                                            code: 0b0,
-                                                            bits: 1,
-                                                        },
-                                                        ShortCodebookDesc { code: 0, bits: 0 },
-                                                        ShortCodebookDesc {
-                                                            code: 0b10,
-                                                            bits: 2,
-                                                        },
-                                                        ShortCodebookDesc { code: 0, bits: 0 },
-                                                        ShortCodebookDesc { code: 0, bits: 0 },
-                                                        ShortCodebookDesc {
-                                                            code: 0b110,
-                                                            bits: 3,
-                                                        },
-                                                        ShortCodebookDesc { code: 0, bits: 0 },
-                                                        ShortCodebookDesc {
-                                                            code: 0b11100,
-                                                            bits: 5,
-                                                        },
-                                                        ShortCodebookDesc {
-                                                            code: 0b11101,
-                                                            bits: 5,
-                                                        },
-                                                        ShortCodebookDesc {
-                                                            code: 0b1111010,
-                                                            bits: 7,
-                                                        },
-                                                        ShortCodebookDesc {
-                                                            code: 0b1111011,
-                                                            bits: 7,
-                                                        },
-                                                        ShortCodebookDesc {
-                                                            code: 0b1111110,
-                                                            bits: 7,
-                                                        },
-                                                        ShortCodebookDesc {
-                                                            code: 0b11111111,
-                                                            bits: 8,
-                                                        }];
+        let mut scb_desc: Vec<ShortCodebookDesc> = vec![
+            ShortCodebookDesc { code: 0b0, bits: 1 },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc {
+                code: 0b10,
+                bits: 2,
+            },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc {
+                code: 0b110,
+                bits: 3,
+            },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc {
+                code: 0b11100,
+                bits: 5,
+            },
+            ShortCodebookDesc {
+                code: 0b11101,
+                bits: 5,
+            },
+            ShortCodebookDesc {
+                code: 0b1111010,
+                bits: 7,
+            },
+            ShortCodebookDesc {
+                code: 0b1111011,
+                bits: 7,
+            },
+            ShortCodebookDesc {
+                code: 0b1111110,
+                bits: 7,
+            },
+            ShortCodebookDesc {
+                code: 0b11111111,
+                bits: 8,
+            },
+        ];
         let buf = &BITS;
         let mut br2 = BitReadBE::new(buf);
         let cb = Codebook::new(&mut scb_desc, CodebookMode::MSB).unwrap();
@@ -509,50 +524,54 @@ mod test {
         assert_eq!(br2.read_cb(&cb).unwrap(), 5);
         assert_eq!(br2.read_cb(&cb).unwrap(), 8);
 
-        assert_eq!(reverse_bits(0b0000_0101_1011_1011_1101_1111_0111_1111),
-                   0b1111_1110_1111_1011_1101_1101_1010_0000);
+        assert_eq!(
+            reverse_bits(0b0000_0101_1011_1011_1101_1111_0111_1111),
+            0b1111_1110_1111_1011_1101_1101_1010_0000
+        );
     }
 
     #[test]
     fn test_short_codebook_lsb() {
         const BITS_LE: [u8; 8] = [0b11101111, 0b01110010, 0b01, 0, 0, 0, 0, 0];
         let buf = &BITS_LE;
-        let mut scble_desc: Vec<ShortCodebookDesc> = vec![ShortCodebookDesc {
-                                                              code: 0b00,
-                                                              bits: 2,
-                                                          },
-                                                          ShortCodebookDesc { code: 0, bits: 0 },
-                                                          ShortCodebookDesc {
-                                                              code: 0b01,
-                                                              bits: 2,
-                                                          },
-                                                          ShortCodebookDesc { code: 0, bits: 0 },
-                                                          ShortCodebookDesc { code: 0, bits: 0 },
-                                                          ShortCodebookDesc {
-                                                              code: 0b011,
-                                                              bits: 3,
-                                                          },
-                                                          ShortCodebookDesc { code: 0, bits: 0 },
-                                                          ShortCodebookDesc {
-                                                              code: 0b10111,
-                                                              bits: 5,
-                                                          },
-                                                          ShortCodebookDesc {
-                                                              code: 0b00111,
-                                                              bits: 5,
-                                                          },
-                                                          ShortCodebookDesc {
-                                                              code: 0b0101111,
-                                                              bits: 7,
-                                                          },
-                                                          ShortCodebookDesc {
-                                                              code: 0b0111111,
-                                                              bits: 7,
-                                                          },
-                                                          ShortCodebookDesc {
-                                                              code: 0b1011101111,
-                                                              bits: 10,
-                                                          }];
+        let mut scble_desc: Vec<ShortCodebookDesc> = vec![
+            ShortCodebookDesc {
+                code: 0b00,
+                bits: 2,
+            },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc {
+                code: 0b01,
+                bits: 2,
+            },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc {
+                code: 0b011,
+                bits: 3,
+            },
+            ShortCodebookDesc { code: 0, bits: 0 },
+            ShortCodebookDesc {
+                code: 0b10111,
+                bits: 5,
+            },
+            ShortCodebookDesc {
+                code: 0b00111,
+                bits: 5,
+            },
+            ShortCodebookDesc {
+                code: 0b0101111,
+                bits: 7,
+            },
+            ShortCodebookDesc {
+                code: 0b0111111,
+                bits: 7,
+            },
+            ShortCodebookDesc {
+                code: 0b1011101111,
+                bits: 10,
+            },
+        ];
         let mut brl = BitReadLE::new(buf);
         let cb = Codebook::new(&mut scble_desc, CodebookMode::LSB).unwrap();
         assert_eq!(brl.read_cb(&cb).unwrap(), 11);

--- a/bitstream/src/lib.rs
+++ b/bitstream/src/lib.rs
@@ -13,5 +13,3 @@ pub mod bitread;
 pub mod byteread;
 pub mod bytewrite;
 pub mod codebook;
-
-

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 repository = "https://github.com/rust-av/rust-av"
+edition = "2018"
 
 [dependencies]
 num-rational = "0.2.2"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/rust-av/rust-av"
 
 [dependencies]
-num-rational = "0.2"
-failure = "0.1.1"
-av-data = "0.1"
+num-rational = "0.2.2"
+failure = "0.1.5"
+av-data = "0.1.0"
 

--- a/codec/src/common.rs
+++ b/codec/src/common.rs
@@ -8,8 +8,8 @@ pub trait Descriptor {
 }
 */
 
-pub trait CodecList : Sized {
-    type D : ?Sized;
+pub trait CodecList: Sized {
+    type D: ?Sized;
 
     fn new() -> Self;
 

--- a/codec/src/decoder.rs
+++ b/codec/src/decoder.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use crate::data::packet::Packet;
 use crate::data::frame::ArcFrame;
+use crate::data::packet::Packet;
 
-use crate::error::*;
 pub use crate::common::CodecList;
+use crate::error::*;
 
-pub trait Decoder : Send {
+pub trait Decoder: Send {
     // TODO support codec configuration using set_option
     // fn open(&mut self) -> Result<()>;
     fn set_extradata(&mut self, extra: &[u8]);
@@ -64,14 +64,16 @@ pub trait Descriptor {
 }
 
 pub struct Codecs {
-    list: HashMap<&'static str, Vec<&'static dyn Descriptor>>
+    list: HashMap<&'static str, Vec<&'static dyn Descriptor>>,
 }
 
 impl CodecList for Codecs {
     type D = dyn Descriptor;
 
     fn new() -> Codecs {
-        Codecs { list: HashMap::new() }
+        Codecs {
+            list: HashMap::new(),
+        }
     }
 
     // TODO more lookup functions
@@ -96,12 +98,12 @@ mod test {
 
     mod dummy {
         use super::super::*;
-        use std::sync::Arc;
         use crate::data::pixel::Formaton;
+        use std::sync::Arc;
 
         struct Dec {
             state: usize,
-            format: Option<Arc<Formaton>>
+            format: Option<Arc<Formaton>>,
         }
 
         pub struct Des {
@@ -110,7 +112,10 @@ mod test {
 
         impl Descriptor for Des {
             fn create(&self) -> Box<dyn Decoder> {
-                Box::new(Dec { state: 0, format: None })
+                Box::new(Dec {
+                    state: 0,
+                    format: None,
+                })
             }
             fn describe<'a>(&'a self) -> &'a Descr {
                 &self.descr
@@ -146,7 +151,7 @@ mod test {
                 name: "dummy",
                 desc: "Dummy encoder",
                 mime: "x-application/dummy",
-            }
+            },
         };
     }
     use self::dummy::DUMMY_DESCR;

--- a/codec/src/encoder.rs
+++ b/codec/src/encoder.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 use std::convert::Into;
 
-use crate::data::packet::Packet;
 use crate::data::frame::ArcFrame;
-use crate::data::value::Value;
+use crate::data::packet::Packet;
 use crate::data::params::CodecParams;
+use crate::data::value::Value;
 
 use crate::error::*;
 
-pub trait Encoder : Send {
+pub trait Encoder: Send {
     fn get_extradata(&self) -> Option<Vec<u8>>;
     fn send_frame(&mut self, pkt: &ArcFrame) -> Result<()>;
     fn receive_packet(&mut self) -> Result<Packet>;
@@ -54,7 +54,8 @@ impl Context {
     }
 
     pub fn set_option<'a, V>(&mut self, key: &str, val: V) -> Result<()>
-        where V: Into<Value<'a>>
+    where
+        V: Into<Value<'a>>,
     {
         // TODO: support more options
         self.enc.set_option(key, val.into())
@@ -91,7 +92,7 @@ pub trait Descriptor {
 }
 
 pub struct Codecs {
-    list: HashMap<&'static str, Vec<&'static dyn Descriptor>>
+    list: HashMap<&'static str, Vec<&'static dyn Descriptor>>,
 }
 
 pub use crate::common::CodecList;
@@ -99,7 +100,9 @@ pub use crate::common::CodecList;
 impl CodecList for Codecs {
     type D = dyn Descriptor;
     fn new() -> Codecs {
-        Codecs { list: HashMap::new() }
+        Codecs {
+            list: HashMap::new(),
+        }
     }
     // TODO more lookup functions
     fn by_name(&self, name: &str) -> Option<&'static dyn Descriptor> {
@@ -122,16 +125,16 @@ mod test {
     use super::*;
 
     mod dummy {
-        use super::super::*;
-        use std::sync::Arc;
-        use crate::data::pixel::Formaton;
         use super::super::super::error::Error;
+        use super::super::*;
+        use crate::data::pixel::Formaton;
+        use std::sync::Arc;
 
         struct Enc {
             state: usize,
             w: Option<usize>,
             h: Option<usize>,
-            format: Option<Arc<Formaton>>
+            format: Option<Arc<Formaton>>,
         }
 
         pub struct Des {
@@ -140,7 +143,12 @@ mod test {
 
         impl Descriptor for Des {
             fn create(&self) -> Box<dyn Encoder> {
-                Box::new(Enc { state: 0, w: None, h: None, format: None })
+                Box::new(Enc {
+                    state: 0,
+                    w: None,
+                    h: None,
+                    format: None,
+                })
             }
             fn describe<'a>(&'a self) -> &'a Descr {
                 &self.descr
@@ -174,7 +182,7 @@ mod test {
                     ("w", Value::U64(v)) => self.w = Some(v as usize),
                     ("h", Value::U64(v)) => self.h = Some(v as usize),
                     ("format", Value::Formaton(f)) => self.format = Some(f),
-                    _ => return Err(Error::Unsupported(format!("{} key", key)))
+                    _ => return Err(Error::Unsupported(format!("{} key", key))),
                 }
 
                 Ok(())
@@ -194,9 +202,7 @@ mod test {
             fn get_params(&self) -> Result<CodecParams> {
                 use crate::data::params::*;
 
-                if self.w.is_none() ||
-                    self.w.is_none() ||
-                        self.format.is_none() {
+                if self.w.is_none() || self.w.is_none() || self.format.is_none() {
                     return Err(Error::ConfigurationIncomplete);
                 }
 
@@ -204,13 +210,13 @@ mod test {
                     kind: Some(MediaKind::Video(VideoInfo {
                         height: self.w.unwrap(),
                         width: self.h.unwrap(),
-                        format: self.format.clone()
+                        format: self.format.clone(),
                     })),
                     codec_id: Some("dummy".to_owned()),
                     extradata: self.get_extradata(),
                     bit_rate: 0,
                     convergence_window: 0,
-                    delay: 0
+                    delay: 0,
                 })
             }
 
@@ -225,7 +231,7 @@ mod test {
                 name: "dummy",
                 desc: "Dummy encoder",
                 mime: "x-application/dummy",
-            }
+            },
         };
     }
     use self::dummy::DUMMY_DESCR;

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -9,9 +9,9 @@ keywords = ["multimedia"]
 readme = "README.md"
 
 [dependencies]
-failure = "0.1.1"
-num-rational = "0.2"
-bytes = "0.4.4"
+failure = "0.1.5"
+num-rational = "0.2.2"
+bytes = "0.4.12"
 byte-slice-cast = "0.3.1"
-enum-primitive-derive = "^0.1"
-num-traits = "^0.2"
+enum-primitive-derive = "0.1.2"
+num-traits = "0.2.8"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 homepage = "https://github.com/rust-av/rust-av"
 keywords = ["multimedia"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 failure = "0.1.5"

--- a/data/src/frame.rs
+++ b/data/src/frame.rs
@@ -4,9 +4,9 @@ use std::alloc::{alloc, Layout};
 
 use std::sync::Arc;
 
-use audiosample::*;
-use pixel::*;
-use timeinfo::*;
+use crate::audiosample::*;
+use crate::pixel::*;
+use crate::timeinfo::*;
 
 use byte_slice_cast::*;
 
@@ -391,7 +391,7 @@ impl Frame {
 #[cfg(test)]
 mod test {
     use super::*;
-    use audiosample::formats;
+    use crate::audiosample::formats;
 
     #[test]
     fn test_format_cmp() {
@@ -434,7 +434,7 @@ mod test {
         assert_eq!(info1 == info2, false);
     }
 
-    use pixel::formats::{RGB565, YUV420};
+    use crate::pixel::formats::{RGB565, YUV420};
 
     #[test]
     fn test_video_format_cmp() {

--- a/data/src/packet.rs
+++ b/data/src/packet.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use std::io::{Read, Result, Write};
 use crate::timeinfo::TimeInfo;
+use std::io::{Read, Result, Write};
 
 // use data::SideData;
 

--- a/data/src/packet.rs
+++ b/data/src/packet.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use std::io::{Read, Result, Write};
-use timeinfo::TimeInfo;
+use crate::timeinfo::TimeInfo;
 
 // use data::SideData;
 

--- a/data/src/params.rs
+++ b/data/src/params.rs
@@ -1,5 +1,5 @@
-use audiosample::{ChannelMap, Soniton};
-use pixel::Formaton;
+use crate::audiosample::{ChannelMap, Soniton};
+use crate::pixel::Formaton;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/data/src/pixel.rs
+++ b/data/src/pixel.rs
@@ -227,12 +227,11 @@ pub enum ColorModel {
 
 impl fmt::Display for ColorModel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::ColorModel::*;
         match *self {
-            Trichromatic(system) => write!(f, "{}", system),
-            CMYK => write!(f, "CMYK"),
-            HSV => write!(f, "HSV"),
-            LAB => write!(f, "LAB"),
+            ColorModel::Trichromatic(system) => write!(f, "{}", system),
+            ColorModel::CMYK => write!(f, "CMYK"),
+            ColorModel::HSV => write!(f, "HSV"),
+            ColorModel::LAB => write!(f, "LAB"),
         }
     }
 }
@@ -509,7 +508,7 @@ pub mod formats {
     use self::TrichromaticEncodingSystem::*;
     use self::YUVRange::*;
     use self::YUVSystem::*;
-    use pixel::*;
+    use crate::pixel::*;
 
     pub const YUV444: &Formaton = &Formaton {
         model: Trichromatic(YUV(YCbCr(Limited))),

--- a/data/src/timeinfo.rs
+++ b/data/src/timeinfo.rs
@@ -1,4 +1,4 @@
-use rational::Rational64;
+use crate::rational::Rational64;
 use std::any::Any;
 use std::sync::Arc;
 

--- a/data/src/value.rs
+++ b/data/src/value.rs
@@ -1,5 +1,5 @@
-use audiosample::Soniton;
-use pixel::Formaton;
+use crate::audiosample::Soniton;
+use crate::pixel::Formaton;
 
 use std::convert::From;
 use std::sync::Arc;

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -6,9 +6,8 @@ authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 
 [dependencies]
-failure = "0.1.1"
-log = "0.4"
+failure = "0.1.5"
+log = "0.4.6"
 
 [dependencies.av-data]
-path = "../data"
-version = "*"
+version = "0.1.0"

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -4,6 +4,7 @@ description = "Multimedia format demuxing and muxing"
 version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 failure = "0.1.5"

--- a/format/src/common.rs
+++ b/format/src/common.rs
@@ -1,5 +1,5 @@
-use data::rational::Rational64;
-use stream::Stream;
+use crate::data::rational::Rational64;
+use crate::stream::Stream;
 
 #[derive(Debug, Clone)]
 pub struct GlobalInfo {

--- a/format/src/demuxer.rs
+++ b/format/src/demuxer.rs
@@ -1,14 +1,14 @@
-use error::*;
+use crate::error::*;
 
-use buffer::Buffered;
+use crate::buffer::Buffered;
 use std::io::SeekFrom;
 use std::any::Any;
 use std::sync::Arc;
 
-use common::*;
+use crate::common::*;
 
-use stream::Stream;
-use data::packet::Packet;
+use crate::stream::Stream;
+use crate::data::packet::Packet;
 
 #[derive(Clone, Debug)]
 pub enum Event {
@@ -177,7 +177,7 @@ impl<'a> Probe for [&'static dyn Descriptor] {
 mod test {
     use super::*;
     use std::io::SeekFrom;
-    use data::packet::Packet;
+    use crate::data::packet::Packet;
 
     struct DummyDes {
         d: Descr,
@@ -248,7 +248,7 @@ mod test {
     }
 
     use std::io::Cursor;
-    use buffer::*;
+    use crate::buffer::*;
 
     #[test]
     fn read_headers() {

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -13,9 +13,9 @@ mod data {
 
 pub use av_data::rational;
 
-pub mod common;
 pub mod buffer;
-pub mod stream;
+pub mod common;
 pub mod demuxer;
-pub mod muxer;
 pub mod error;
+pub mod muxer;
+pub mod stream;

--- a/format/src/muxer.rs
+++ b/format/src/muxer.rs
@@ -1,9 +1,9 @@
 use crate::common::*;
-use crate::data::value::*;
 use crate::data::packet::Packet;
-use std::sync::Arc;
-use std::io::Write;
+use crate::data::value::*;
 use std::any::Any;
+use std::io::Write;
+use std::sync::Arc;
 
 use crate::error::*;
 
@@ -42,12 +42,12 @@ impl Context {
         self.muxer.write_header(&mut self.buf)?;
         //FIXME: we should have proper management of the buffer's index
         match self.writer.write_all(&self.buf) {
-          Ok(()) => {
-            let len = self.buf.len();
-            self.buf.clear();
-            Ok(len)
-          },
-          Err(e) => Err(Error::Io(e)),
+            Ok(()) => {
+                let len = self.buf.len();
+                self.buf.clear();
+                Ok(len)
+            }
+            Err(e) => Err(Error::Io(e)),
         }
     }
 
@@ -55,12 +55,12 @@ impl Context {
         self.muxer.write_packet(&mut self.buf, pkt)?;
         //FIXME: we should have proper management of the buffer's index
         match self.writer.write_all(&self.buf) {
-          Ok(()) => {
-            let len = self.buf.len();
-            self.buf.clear();
-            Ok(len)
-          },
-          Err(e) => Err(Error::Io(e)),
+            Ok(()) => {
+                let len = self.buf.len();
+                self.buf.clear();
+                Ok(len)
+            }
+            Err(e) => Err(Error::Io(e)),
         }
     }
 
@@ -68,12 +68,12 @@ impl Context {
         self.muxer.write_trailer(&mut self.buf)?;
         //FIXME: we should have proper management of the buffer's index
         match self.writer.write_all(&self.buf) {
-          Ok(()) => {
-            let len = self.buf.len();
-            self.buf.clear();
-            Ok(len)
-          },
-          Err(e) => Err(Error::Io(e)),
+            Ok(()) => {
+                let len = self.buf.len();
+                self.buf.clear();
+                Ok(len)
+            }
+            Err(e) => Err(Error::Io(e)),
         }
     }
 
@@ -82,7 +82,9 @@ impl Context {
     }
 
     pub fn set_option<'a, V>(&mut self, key: &str, val: V) -> Result<()>
-        where V: Into<Value<'a>> {
+    where
+        V: Into<Value<'a>>,
+    {
         self.muxer.set_option(key, val.into())
     }
 }

--- a/format/src/muxer.rs
+++ b/format/src/muxer.rs
@@ -1,11 +1,11 @@
-use common::*;
-use data::value::*;
-use data::packet::Packet;
+use crate::common::*;
+use crate::data::value::*;
+use crate::data::packet::Packet;
 use std::sync::Arc;
 use std::io::Write;
 use std::any::Any;
 
-use error::*;
+use crate::error::*;
 
 pub trait Muxer: Send {
     fn configure(&mut self) -> Result<()>;

--- a/format/src/stream.rs
+++ b/format/src/stream.rs
@@ -1,5 +1,5 @@
-use data::params::CodecParams;
-use rational::Rational64;
+use crate::data::params::CodecParams;
+use crate::rational::Rational64;
 use std::any::Any;
 use std::sync::Arc;
 

--- a/src/io/byteread.rs
+++ b/src/io/byteread.rs
@@ -19,7 +19,7 @@ fn get_buffer<R: Read + ?Sized>(reader: &mut R, buf: &mut [u8]) -> Result<()> {
 macro_rules! get {
     ($s: ident, $name: ident, $size: expr) => ({
         let mut buf = [0; $size];
-        try!(get_buffer($s, &mut buf));
+        get_buffer($s, &mut buf)?;
         Ok($name(&buf))
     })
 }
@@ -85,7 +85,7 @@ impl<R: Read + ?Sized> ByteRead for R {}
 
 macro_rules! peek {
    ($s: ident, $name: ident, $size: expr) => ({
-        let buf = try!($s.fill_buf());
+        let buf = $s.fill_buf()?;
         if buf.len() < $size {
             Err(Error::new(UnexpectedEof, "Empty"))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 // workarounds
 #![allow(unused_doc_comments)]
 
-// language extensions
-#![feature(box_syntax, plugin, rust_2018_preview)]
-
 // crates
 
 // local crates


### PR DESCRIPTION
This PR contains a host of fixes and formatting changes that update `rust-av` for compilation on Rust's 2018 Edition. I can roll up these changes if that's preferable, but I wanted to leave them separate by default to make cherry-picking easier.

Hopefully, these changes will also mean `rust-av` can drop the requirement on `rustc +nightly`, too, but that vision has yet to be fully realized.

Looking at issues, it seems that merging this PR would resolve #61 (again, because best practices have shifted, I believe).