### PR TITLE
handle the case where we want to demux again but don't need more data

### DIFF
--- a/format/src/demuxer.rs
+++ b/format/src/demuxer.rs
@@ -130,6 +130,12 @@ impl Context {
                 Err(e) => match e {
                     Error::MoreDataNeeded(needed) => {
                         let len = self.reader.data().len();
+
+                        // we might have sent MoreDatNeeded(0) to request a new call
+                        if len >= needed {
+                          println!("available length {} >= requested needed {}, continuing", len, needed);
+                          continue
+                        }
                         self.reader.grow(needed);
                         self.reader.fill_buf()?;
                         if self.reader.data().len() <= len {


### PR DESCRIPTION
ok, so here is a quick fix for the issue of `matroska_remux` not writing the `Cluster` element.

What's happening:
- in the MKV demuxer, we want to ignore elements between `Tracks` and `Cluster` (most likely, we're ignoring a `Tags` element: https://github.com/rust-av/matroska/blob/master/src/demuxer.rs#L151-L155
- since it returned `MoreDataNeeded(0)`, we're in the general demuxer code's case where we want to seek and request more data: https://github.com/rust-av/rust-av/blob/master/format/src/demuxer.rs#L106-L108
- we ask for more data, so we try to grow the buffer, but for a small file, we probably already read everything, so it returns EOF: https://github.com/rust-av/rust-av/blob/master/format/src/demuxer.rs#L131-L136
- that EOF events bubbles up to matroska_remux, so we do not continue parsing
- since we received EOF, the muxer writes the trailer and stops: https://github.com/rust-av/matroska/blob/master/examples/matroska_remux.rs#L43-L44

So in the quick fix, I make sure that if we return `Event::MoreDataNeeded`, but there's already enough data, we try again, which apparently works, but is not really nice.

Here's what I propose:
- adding an `Event::Continue` variant so that a demuxer can say "I did not produce anything, but everything is fine, call me again"
- I'd have that `Event::Continue` bubble up to the code calling the demuxer, so it can decide if it continues or not (maybe wants to yield to some other code?)
- checking that we reached EOF on that condition is awkward: https://github.com/rust-av/rust-av/blob/master/format/src/demuxer.rs#L135 the reader should be able to send EOF itself (or even WouldBlock) and we would handle it properly