### PR TITLE
Make the Event non-exaustive

### DIFF
--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "av-format"
 description = "Multimedia format demuxing and muxing"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 edition = "2018"

--- a/format/src/demuxer.rs
+++ b/format/src/demuxer.rs
@@ -17,6 +17,10 @@ pub enum Event {
     MoreDataNeeded(usize),
     Continue,
     Eof,
+    // use #[non_exhaustive] once this works:
+    // https://github.com/rust-lang/rust/issues/44109
+    #[doc(hidden)]
+    __NonExaustive
 }
 
 pub trait Demuxer: Send {


### PR DESCRIPTION
I would bump it as 0.2.0 and then bake a release.