### PR TITLE
Replace unsafe operations

### DIFF
--- a/bitstream/src/byteread.rs
+++ b/bitstream/src/byteread.rs
@@ -1,61 +1,62 @@
-#![allow(dead_code)]
-
-use std::ptr;
-/**
- * Unsafe building blocks
- */
-
 // TODO: arch-specific version
 // TODO: aligned/non-aligned version
 
-macro_rules! read_num_bytes {
-    ($ty:ty, $size:expr, $src:expr, $which:ident) => {{
-        let mut data: $ty = 0;
-        unsafe {
-            ptr::copy_nonoverlapping($src.as_ptr(), &mut data as *mut $ty as *mut u8, $size);
-        }
-        data.$which()
-    }};
-}
-
 #[inline]
 pub fn get_u8(buf: &[u8]) -> u8 {
+    assert!(buf.len() > 0);
     buf[0] as u8
 }
 
 #[inline]
 pub fn get_i8(buf: &[u8]) -> i8 {
+    assert!(buf.len() > 0);
     buf[0] as i8
 }
 
 #[inline]
 pub fn get_u16l(buf: &[u8]) -> u16 {
-    read_num_bytes!(u16, 2, buf, to_le)
+    assert!(buf.len() > 1);
+    let data = [buf[0], buf[1]];
+    u16::from_le_bytes(data)
 }
 
 #[inline]
 pub fn get_u16b(buf: &[u8]) -> u16 {
-    read_num_bytes!(u16, 2, buf, to_be)
+    assert!(buf.len() > 1);
+    let data = [buf[0], buf[1]];
+    u16::from_be_bytes(data)
 }
 
 #[inline]
 pub fn get_u32l(buf: &[u8]) -> u32 {
-    read_num_bytes!(u32, 4, buf, to_le)
+    assert!(buf.len() > 3);
+    let data = [buf[0], buf[1], buf[2], buf[3]];
+    u32::from_le_bytes(data)
 }
 
 #[inline]
 pub fn get_u32b(buf: &[u8]) -> u32 {
-    read_num_bytes!(u32, 4, buf, to_be)
+    assert!(buf.len() > 3);
+    let data = [buf[0], buf[1], buf[2], buf[3]];
+    u32::from_be_bytes(data)
 }
 
 #[inline]
 pub fn get_u64l(buf: &[u8]) -> u64 {
-    read_num_bytes!(u64, 8, buf, to_le)
+    assert!(buf.len() > 7);
+    let data = [
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
+    ];
+    u64::from_le_bytes(data)
 }
 
 #[inline]
 pub fn get_u64b(buf: &[u8]) -> u64 {
-    read_num_bytes!(u64, 8, buf, to_be)
+    assert!(buf.len() > 7);
+    let data = [
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
+    ];
+    u64::from_be_bytes(data)
 }
 
 #[inline]

--- a/bitstream/src/bytewrite.rs
+++ b/bitstream/src/bytewrite.rs
@@ -1,17 +1,15 @@
-#![allow(dead_code)]
+macro_rules! write_bytes_le {
+    ($buf:ident, $n:ident) => {
+        let bytes = $n.to_le_bytes();
+        $buf.to_vec().extend_from_slice(&bytes);
+    };
+}
 
-use std::mem::transmute;
-use std::ptr::copy_nonoverlapping;
-
-macro_rules! write_num_bytes {
-    ($ty:ty, $size:expr, $dst:expr, $n:expr, $which:ident) => {{
-        assert!($size <= $dst.len());
-        unsafe {
-            // N.B. https://github.com/rust-lang/rust/issues/22776
-            let bytes = transmute::<_, [u8; $size]>($n.$which());
-            copy_nonoverlapping((&bytes).as_ptr(), $dst.as_mut_ptr(), $size);
-        }
-    }};
+macro_rules! write_bytes_be {
+    ($buf:ident, $n:ident) => {
+        let bytes = $n.to_be_bytes();
+        $buf.to_vec().extend_from_slice(&bytes);
+    };
 }
 
 #[inline]
@@ -26,32 +24,32 @@ pub fn put_i8(buf: &mut [u8], n: i8) {
 
 #[inline]
 pub fn put_u16l(buf: &mut [u8], n: u16) {
-    write_num_bytes!(u16, 2, buf, n, to_le);
+    write_bytes_le!(buf, n);
 }
 
 #[inline]
 pub fn put_u16b(buf: &mut [u8], n: u16) {
-    write_num_bytes!(u16, 2, buf, n, to_be);
+    write_bytes_be!(buf, n);
 }
 
 #[inline]
 pub fn put_u32l(buf: &mut [u8], n: u32) {
-    write_num_bytes!(u32, 4, buf, n, to_le);
+    write_bytes_le!(buf, n);
 }
 
 #[inline]
 pub fn put_u32b(buf: &mut [u8], n: u32) {
-    write_num_bytes!(u32, 4, buf, n, to_be);
+    write_bytes_be!(buf, n);
 }
 
 #[inline]
 pub fn put_u64l(buf: &mut [u8], n: u64) {
-    write_num_bytes!(u64, 8, buf, n, to_le);
+    write_bytes_le!(buf, n);
 }
 
 #[inline]
 pub fn put_u64b(buf: &mut [u8], n: u64) {
-    write_num_bytes!(u64, 8, buf, n, to_be);
+    write_bytes_be!(buf, n);
 }
 
 #[inline]
@@ -86,22 +84,22 @@ pub fn put_i64b(buf: &mut [u8], n: i64) {
 
 #[inline]
 pub fn put_f32l(buf: &mut [u8], n: f32) {
-    put_u32l(buf, unsafe { transmute(n) });
+    write_bytes_le!(buf, n);
 }
 
 #[inline]
 pub fn put_f32b(buf: &mut [u8], n: f32) {
-    put_u32b(buf, unsafe { transmute(n) });
+    write_bytes_be!(buf, n);
 }
 
 #[inline]
 pub fn put_f64l(buf: &mut [u8], n: f64) {
-    put_u64l(buf, unsafe { transmute(n) });
+    write_bytes_le!(buf, n);
 }
 
 #[inline]
 pub fn put_f64b(buf: &mut [u8], n: f64) {
-    put_u64b(buf, unsafe { transmute(n) });
+    write_bytes_be!(buf, n);
 }
 
 #[cfg(test)]

--- a/bitstream/src/lib.rs
+++ b/bitstream/src/lib.rs
@@ -1,6 +1,3 @@
-// language extensions
-// #![feature(rust_2018_preview)]
-
 extern crate num_traits;
 
 #[cfg(test)]


### PR DESCRIPTION
Remove unsafe operations from the `bitstream` crate, replacing them with safe functions. If I'm not mistaken, this PR closes #38 and #39