### PR TITLE
Fix bytewrite methods for types other than u8

### DIFF
--- a/bitstream/Cargo.toml
+++ b/bitstream/Cargo.toml
@@ -13,3 +13,4 @@ num-traits = "0.2.8"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
+paste = "0.1.18"


### PR DESCRIPTION
The usage of `to_vec` clones the input slice,
meaning the original input buffer is never written to.