### PR TITLE
Change Muxer trait to take `&mut Write`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.2.1"
 path = "data"
 
 [dependencies.av-format]
-version = "0.2.0"
+version = "0.3.0"
 path = "format"
 
 [dependencies.av-bitstream]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/rust-av/rust-av"
 edition = "2018"
 
 [dev_dependencies]
-av-codec = { path = "../codec" }
-av-data = { path = "../data" }
-av-format = { path = "../format" }
+av-codec = "0.2.0"
+av-data = "0.2.1"
+av-format = "0.2.1"
 clap = "2.33.1"
 matroska = { version = "0.1.0", git = "https://github.com/rust-av/matroska" }
 av-vorbis = { git = "https://github.com/rust-av/av-vorbis" }

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "av-format"
 description = "Multimedia format demuxing and muxing"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 edition = "2018"

--- a/format/src/muxer.rs
+++ b/format/src/muxer.rs
@@ -9,9 +9,9 @@ use crate::error::*;
 
 pub trait Muxer: Send {
     fn configure(&mut self) -> Result<()>;
-    fn write_header(&mut self, buf: &mut Vec<u8>) -> Result<()>;
-    fn write_packet(&mut self, buf: &mut Vec<u8>, pkt: Arc<Packet>) -> Result<()>;
-    fn write_trailer(&mut self, buf: &mut Vec<u8>) -> Result<()>;
+    fn write_header(&mut self, out: &mut dyn Write) -> Result<()>;
+    fn write_packet(&mut self, out: &mut dyn Write, pkt: Arc<Packet>) -> Result<()>;
+    fn write_trailer(&mut self, out: &mut dyn Write) -> Result<()>;
 
     fn set_global_info(&mut self, info: GlobalInfo) -> Result<()>;
     fn set_option<'a>(&mut self, key: &str, val: Value<'a>) -> Result<()>;


### PR DESCRIPTION
This allows writing to other sources, e.g. Files, directly,
without an intermediate Vec buffer.

Closes #123.