### PR TITLE
Clarify timeinfo documentation

### DIFF
--- a/data/src/timeinfo.rs
+++ b/data/src/timeinfo.rs
@@ -2,7 +2,7 @@ use crate::rational::Rational64;
 use std::any::Any;
 use std::sync::Arc;
 
-/// Timestamp information.
+/// Timestamp information for frames and packets.
 #[derive(Debug, Clone, Default)]
 pub struct TimeInfo {
     /// Presentation timestamp.
@@ -11,7 +11,10 @@ pub struct TimeInfo {
     pub dts: Option<i64>,
     /// Duration (in timebase units).
     pub duration: Option<u64>,
-    /// Timebase numerator/denominator.
+    /// Timebase numerator/denominator (i.e 1/75th of a second).
+    ///
+    /// Its value does not vary among frames/packets, since it is
+    /// computed and defined at stream level.
     pub timebase: Option<Rational64>,
     /// Timebase user private data.
     pub user_private: Option<Arc<dyn Any + Send + Sync>>,


### PR DESCRIPTION
This PR clarifies for what  the `TimeInfo` struct is used and makes the explanation of the `timebase` field more precise.