### PR TITLE
Add Sync trait to some `rust-av` traits to use them concurrently 

### DIFF
--- a/codec/src/decoder.rs
+++ b/codec/src/decoder.rs
@@ -7,7 +7,7 @@ pub use crate::common::CodecList;
 use crate::error::*;
 
 /// Used to interact with a decoder.
-pub trait Decoder: Send {
+pub trait Decoder: Send + Sync {
     // TODO support codec configuration using set_option
     // fn open(&mut self) -> Result<()>;
     /// Saves the extra data contained in a codec.

--- a/format/src/buffer/accreader.rs
+++ b/format/src/buffer/accreader.rs
@@ -85,7 +85,7 @@ impl<R: Read + Seek> AccReader<R> {
     }
 }
 
-impl<R: Read + Seek + Send> Buffered for AccReader<R> {
+impl<R: Read + Seek + Send + Sync> Buffered for AccReader<R> {
     fn data(&self) -> &[u8] {
         &self.buf[self.pos..self.end]
     }

--- a/format/src/buffer/mod.rs
+++ b/format/src/buffer/mod.rs
@@ -5,7 +5,7 @@ pub use self::accreader::AccReader;
 use std::io::{BufRead, Seek};
 
 /// Used to interact with a buffer.
-pub trait Buffered: BufRead + Seek + Send {
+pub trait Buffered: BufRead + Seek + Send + Sync {
     /// Returns the data contained in a buffer as a sequence of bytes.
     fn data(&self) -> &[u8];
     /// Increases the size of a buffer.

--- a/format/src/demuxer.rs
+++ b/format/src/demuxer.rs
@@ -33,7 +33,7 @@ pub enum Event {
 }
 
 /// Used to implement demuxing operations.
-pub trait Demuxer: Send {
+pub trait Demuxer: Send + Sync {
     /// Reads stream headers and global information from a data structure
     /// implementing the `Buffered` trait.
     ///


### PR DESCRIPTION
This PR adds the `Sync` trait to some of the traits implemented in `rust-av` in order to use them concurrently. 