### PR TITLE
Add generics in demuxer code

### DIFF
--- a/format/src/demuxer.rs
+++ b/format/src/demuxer.rs
@@ -71,6 +71,11 @@ impl<D: Demuxer, R: Buffered> Context<D, R> {
         }
     }
 
+    /// Returns the underlying demuxer.
+    pub fn demuxer(&self) -> &D {
+        &self.demuxer
+    }
+
     fn read_headers_internal(&mut self) -> Result<()> {
         let demux = &mut self.demuxer;
 


### PR DESCRIPTION
This PR:
- Replace Box with a generic for Reader
- Replace Box with a generic for Demuxer
- Add an API to retrieve the underlying demuxer