### PR TITLE
Add generics in muxer code 

### DIFF
--- a/format/src/muxer.rs
+++ b/format/src/muxer.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use crate::error::*;
 
+/// A trait for a non-seekable object.
 pub trait WriteOwned: Write + ToOwned {}
+/// A trait for a seekable object.
 pub trait WriteSeek: Write + Seek + ToOwned {}
 
 impl<T: Write + ToOwned> WriteOwned for T {}

--- a/format/src/muxer.rs
+++ b/format/src/muxer.rs
@@ -324,13 +324,43 @@ mod test {
         muxers.by_name("dummy").unwrap();
     }
 
-    #[test]
-    fn write_header() {
+    fn create_muxer() -> Context<DummyMuxer, Cursor<Vec<u8>>, Cursor<Vec<u8>>> {
         let mux = DummyMuxer::new();
         let writer = Writer::from_seekable(Cursor::new(Vec::new()));
 
-        let mut muxer = Context::new(mux, writer);
+        Context::new(mux, writer)
+    }
+
+    #[test]
+    fn write_header() {
+        let mut muxer = create_muxer();
         muxer.configure().unwrap();
         muxer.write_header().unwrap();
+    }
+
+    #[test]
+    fn write_packets() {
+        let mut muxer = create_muxer();
+        muxer.configure().unwrap();
+        muxer.write_header().unwrap();
+
+        for _ in 0..10 {
+            let packet = Packet::zeroed(10);
+            muxer.write_packet(Arc::new(packet)).unwrap();
+        }
+    }
+
+    #[test]
+    fn write_trailer() {
+        let mut muxer = create_muxer();
+        muxer.configure().unwrap();
+        muxer.write_header().unwrap();
+
+        for _ in 0..10 {
+            let packet = Packet::zeroed(10);
+            muxer.write_packet(Arc::new(packet)).unwrap();
+        }
+
+        muxer.write_trailer().unwrap();
     }
 }

--- a/format/src/muxer.rs
+++ b/format/src/muxer.rs
@@ -166,6 +166,11 @@ impl<M: Muxer + Send, W: Write, WS: WriteSeek> Context<M, W, WS> {
     {
         self.muxer.set_option(key, val.into())
     }
+
+    /// Returns the underlying writer.
+    pub fn writer(&self) -> &Writer<W, WS> {
+        &self.writer
+    }
 }
 
 /// Format descriptor.


### PR DESCRIPTION
This PR:
- Replace Box with a generic for Muxer
- Replace Box with a generic for Writer
- Add an API to retrieve the underlying muxer
- Add some APIs to retrieve the underlying buffer
- Add tests for muxer