### PR TITLE
Add generic in encoder code

### DIFF
--- a/codec/src/encoder.rs
+++ b/codec/src/encoder.rs
@@ -50,12 +50,9 @@ impl<E: Encoder> Context<E> {
         codecs: &Codecs<T>,
         name: &str,
     ) -> Option<Self> {
-        if let Some(builder) = codecs.by_name(name) {
-            let enc = builder.create();
-            Some(Context { enc })
-        } else {
-            None
-        }
+        codecs.by_name(name).map(|builder| Context {
+            enc: builder.create(),
+        })
     }
 
     /// Configures the encoder.

--- a/codec/src/encoder.rs
+++ b/codec/src/encoder.rs
@@ -97,6 +97,11 @@ impl<E: Encoder> Context<E> {
     pub fn flush(&mut self) -> Result<()> {
         self.enc.flush()
     }
+
+    /// Returns the underlying encoder.
+    pub fn encoder(&self) -> &E {
+        &self.enc
+    }
 }
 
 /// Codec descriptor.


### PR DESCRIPTION
This PR:

- Replace Box with a generic for Encoder
- Add an API to retrieve the underlying encoder

