### PR TITLE
Add generics in decoder code

### DIFF
--- a/codec/src/decoder.rs
+++ b/codec/src/decoder.rs
@@ -53,12 +53,9 @@ impl<D: Decoder> Context<D> {
         codecs: &Codecs<T>,
         name: &str,
     ) -> Option<Self> {
-        if let Some(builder) = codecs.by_name(name) {
-            let dec = builder.create();
-            Some(Context { dec })
-        } else {
-            None
-        }
+        codecs.by_name(name).map(|builder| Context {
+            dec: builder.create(),
+        })
     }
     /// Saves the extra data contained in a codec.
     pub fn set_extradata(&mut self, extra: &[u8]) {

--- a/codec/src/decoder.rs
+++ b/codec/src/decoder.rs
@@ -105,7 +105,7 @@ impl<T: Descriptor + ?Sized> CodecList for Codecs<T> {
     type D = T;
 
     fn new() -> Self {
-        Codecs {
+        Self {
             list: HashMap::new(),
         }
     }

--- a/codec/src/decoder.rs
+++ b/codec/src/decoder.rs
@@ -79,6 +79,11 @@ impl<D: Decoder> Context<D> {
     pub fn flush(&mut self) -> Result<()> {
         self.dec.flush()
     }
+
+    /// Returns the underlying decoder.
+    pub fn decoder(&self) -> &D {
+        &self.dec
+    }
 }
 
 /// Used to get the descriptor of a codec and create its own decoder.

--- a/codec/src/decoder.rs
+++ b/codec/src/decoder.rs
@@ -131,13 +131,9 @@ mod test {
 
     mod dummy {
         use super::super::*;
-        use crate::data::pixel::Formaton;
-        use std::sync::Arc;
 
         pub struct Dec {
             state: usize,
-            #[allow(dead_code)]
-            format: Option<Arc<Formaton>>,
         }
 
         pub struct Des {
@@ -148,10 +144,7 @@ mod test {
             type OutputDecoder = Dec;
 
             fn create(&self) -> Self::OutputDecoder {
-                Dec {
-                    state: 0,
-                    format: None,
-                }
+                Dec { state: 0 }
             }
 
             fn describe(&self) -> &Descr {

--- a/codec/src/encoder.rs
+++ b/codec/src/encoder.rs
@@ -139,7 +139,7 @@ impl<T: Descriptor + ?Sized> CodecList for Codecs<T> {
     type D = T;
 
     fn new() -> Self {
-        Codecs {
+        Self {
             list: HashMap::new(),
         }
     }


### PR DESCRIPTION
This PR:

- Replace Box with a generic for Decoder
- Add an API to retrieve the underlying decoder
- Clean up encoder and decoder code a bit

