### PR TITLE
Fix an API misuse

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-byte-slice-cast = "1.0.0"
-bytes = "1.0.0"
+byte-slice-cast = "1.2.1"
+bytes = "1.2.1"
 thiserror = "1.0"
 num-rational = "0.4.0"
 num-traits = "0.2.8"

--- a/data/src/frame.rs
+++ b/data/src/frame.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code, unused_variables)]
 
-use std::alloc::{alloc, Layout};
 use std::convert::From;
 use std::fmt;
 use std::ptr::copy_nonoverlapping;
@@ -388,9 +387,7 @@ impl DefaultFrameBuffer {
         match *kind {
             MediaKind::Video(ref video) => {
                 let size = video.size(ALIGNMENT);
-                let data = unsafe { alloc(Layout::from_size_align(size, ALIGNMENT).unwrap()) };
-                //let data = unsafe { Heap.alloc_zeroed(Layout::from_size_align(size, ALIGNMENT)) };
-                let buf = BytesMut::from(unsafe { &Vec::from_raw_parts(data, size, size)[..] });
+                let buf = BytesMut::with_capacity(size);
                 let mut buffer = DefaultFrameBuffer {
                     buf,
                     planes: Vec::with_capacity(video.format.get_num_comp()),
@@ -409,8 +406,7 @@ impl DefaultFrameBuffer {
             }
             MediaKind::Audio(ref audio) => {
                 let size = audio.size(ALIGNMENT);
-                let data = unsafe { alloc(Layout::from_size_align(size, ALIGNMENT).unwrap()) };
-                let buf = BytesMut::from(unsafe { &Vec::from_raw_parts(data, size, size)[..] });
+                let buf = BytesMut::with_capacity(size);
                 let mut buffer = DefaultFrameBuffer {
                     buf,
                     planes: if audio.format.planar {
@@ -616,8 +612,6 @@ mod test {
 
     #[test]
     #[should_panic]
-    // FIXME: On Windows this test does not work
-    #[cfg(target_os = "linux")]
     fn test_frame_copy_from_slice() {
         let yuv420: Formaton = *YUV420;
         let fm = Arc::new(yuv420);


### PR DESCRIPTION
This PR fixes an API misuse, `BytesMut` was reading not yet initialized memory. This also fixes a test on Windows.