### PR TITLE
Add a safety comment to unsafe code

### DIFF
--- a/data/src/frame.rs
+++ b/data/src/frame.rs
@@ -547,6 +547,8 @@ fn copy_plane(
     let src_chunks = src.chunks(src_linesize);
 
     for (d, s) in dst_chunks.zip(src_chunks).take(height) {
+        // SAFETY:
+        // dst and src slices are initialized.
         unsafe {
             copy_nonoverlapping(s.as_ptr(), d.as_mut_ptr(), width);
         }


### PR DESCRIPTION
This PR adds a `SAFETY` comment to the unique unsafe block in the code 