### PR TITLE
Document all public items

### DIFF
--- a/bitstream/src/bitread.rs
+++ b/bitstream/src/bitread.rs
@@ -1,3 +1,5 @@
+//! Bitstream reader functionality.
+
 use crate::byteread::*;
 
 /// Used to interact with a sequence of 64 bits, taking into account the

--- a/bitstream/src/byteread.rs
+++ b/bitstream/src/byteread.rs
@@ -1,3 +1,5 @@
+//! Bytestream reader functionality.
+
 // TODO: arch-specific version
 // TODO: aligned/non-aligned version
 

--- a/bitstream/src/bytewrite.rs
+++ b/bitstream/src/bytewrite.rs
@@ -1,3 +1,5 @@
+//! Bytestream writing functionality.
+
 macro_rules! write_bytes_le {
     ($buf:ident, $n:ident) => {
         let bytes = $n.to_le_bytes();

--- a/bitstream/src/codebook.rs
+++ b/bitstream/src/codebook.rs
@@ -1,3 +1,7 @@
+//! Codebook support for bitstream reader.
+//!
+//! Codebook is a set of unique bit strings and values assigned to them.
+
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::marker::PhantomData;

--- a/bitstream/src/lib.rs
+++ b/bitstream/src/lib.rs
@@ -1,4 +1,6 @@
-#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
+
+//! Bytes and bitstream reading/writing functionality.
 
 pub mod bitread;
 pub mod byteread;

--- a/bitstream/src/lib.rs
+++ b/bitstream/src/lib.rs
@@ -1,6 +1,6 @@
-#![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
-
 //! Bytes and bitstream reading/writing functionality.
+
+#![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
 
 pub mod bitread;
 pub mod byteread;

--- a/codec/src/decoder.rs
+++ b/codec/src/decoder.rs
@@ -88,6 +88,7 @@ impl<D: Decoder> Context<D> {
 
 /// Used to get the descriptor of a codec and create its own decoder.
 pub trait Descriptor {
+    /// The specific type of the decoder.
     type OutputDecoder: Decoder;
 
     /// Creates a new decoder for the requested codec.

--- a/codec/src/encoder.rs
+++ b/codec/src/encoder.rs
@@ -123,6 +123,7 @@ pub struct Descr {
 
 /// Used to get the descriptor of a codec and create its own encoder.
 pub trait Descriptor {
+    /// The specific type of the encoder.
     type OutputEncoder: Encoder;
 
     /// Creates a new encoder for the requested codec.

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
 
 pub mod common;
 pub mod decoder;

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -2,11 +2,11 @@
 
 #![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
 
-/// Data structs shared between encoders and decoders
+/// Data structs shared between encoders and decoders.
 pub mod common;
-/// Utilities for decoding video and audio formats
+/// Utilities for decoding video and audio formats.
 pub mod decoder;
-/// Utilities for encoding video and audio formats
+/// Utilities for encoding video and audio formats.
 pub mod encoder;
-/// Error types
+/// Error types.
 pub mod error;

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -1,6 +1,12 @@
+//! Contains utilities for encoding and decoding video and audio formats.
+
 #![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
 
+/// Data structs shared between encoders and decoders
 pub mod common;
+/// Utilities for decoding video and audio formats
 pub mod decoder;
+/// Utilities for encoding video and audio formats
 pub mod encoder;
+/// Error types
 pub mod error;

--- a/data/src/audiosample.rs
+++ b/data/src/audiosample.rs
@@ -1,3 +1,5 @@
+//! Audio sample format definitions.
+
 use std::fmt;
 use std::string::*;
 
@@ -80,33 +82,68 @@ impl fmt::Display for Soniton {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ChannelType {
+    /// Center front.
     C,
+    /// Left front.
     L,
+    /// Right front.
     R,
+    /// Center surround.
     Cs,
+    /// Left surround.
     Ls,
+    /// Right surround.
     Rs,
+    /// Left surround side.
     Lss,
+    /// Right surround side.
     Rss,
+    /// Low Frequency Effect.
     LFE,
+    /// Left center.
     Lc,
+    /// Right center.
     Rc,
+    /// Left height.
     Lh,
+    /// Right height.
     Rh,
+    /// Center height.
     Ch,
+    /// Second Low Frequency Effect.
     LFE2,
+    /// Left wide.
     Lw,
+    /// Right wide.
     Rw,
+    /// Overhead.
+    ///
+    /// Known also as:
+    /// - Over the listener head (Oh) in DTS specification (ETSI TS 102.114)
+    /// - Top Center Surround (Ts) in SMPTE 428-3-2006 specification
     Ov,
+    /// Left height side.
     Lhs,
+    /// Right height side.
     Rhs,
+    /// Center height side.
     Chs,
+    /// Left in the plane lower then listener's ears
+    /// (DTS specification ETSI TS 102.114).
     Ll,
+    /// Right in the plane lower then listener's ears
+    /// (DTS specification ETSI TS 102.114).
     Rl,
+    /// Center in the plane lower then listener's ears
+    /// (DTS specification ETSI TS 102.114).
     Cl,
+    /// Left total (SMPTE 428-3-2006 specification).
     Lt,
+    /// Right total (SMPTE 428-3-2006 specification).
     Rt,
+    /// Left-only downmix mode (Dolby ETSI TS 102.366 specification).
     Lo,
+    /// Right-only downmix mode (Dolby ETSI TS 102.366 specification).
     Ro,
 }
 

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,5 +1,8 @@
-#![deny(clippy::undocumented_unsafe_blocks)]
+//! Structs and traits to interact with multimedia data.
 
+#![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
+
+/// A module to represent and interact with rational numbers.
 pub mod rational {
     pub use num_rational::*;
 }

--- a/data/src/packet.rs
+++ b/data/src/packet.rs
@@ -1,3 +1,5 @@
+//! Packets definitions.
+
 #![allow(dead_code)]
 
 use crate::timeinfo::TimeInfo;

--- a/data/src/params.rs
+++ b/data/src/params.rs
@@ -1,3 +1,5 @@
+//! Video and audio definitions.
+
 use crate::audiosample::{ChannelMap, Soniton};
 use crate::pixel::Formaton;
 use std::sync::Arc;

--- a/data/src/pixel.rs
+++ b/data/src/pixel.rs
@@ -29,24 +29,69 @@ impl fmt::Display for YUVRange {
     }
 }
 
+/// Describes the matrix coefficients used in deriving
+/// luma and chroma signals from the green, blue and red or X, Y and Z primaries.
+///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 pub enum MatrixCoefficients {
+    /// The identity matrix.
+    /// Typically used for:
+    ///
+    /// - GBR (often referred to as RGB)
+    /// - YZX (often referred to as XYZ)
+    /// - IEC 61966-2-1 sRGB
+    /// - SMPTE ST 428-1 (2019)
     Identity = 0,
+    /// - Rec. ITU-R BT.709-6
+    /// - Rec. ITU-R BT.1361-0 conventional colour gamut system and extended colour
+    /// - gamut system (historical)
+    /// - IEC 61966-2-4 xvYCC709
+    /// - SMPTE RP 177 (1993) Annex B
     BT709 = 1,
+    /// Image characteristics are unknown or are determined by the application
     Unspecified = 2,
+    /// For future use by ITU-T | ISO/IEC
     Reserved = 3,
+    /// United States Federal Communications Commission (2003) Title 47 Code of
+    /// Federal Regulations 73.682 (a) (20)
     BT470M = 4,
+    /// - Rec. ITU-R BT.470-6 System B, G (historical)
+    /// - Rec. ITU-R BT.601-7 625
+    /// - Rec. ITU-R BT.1358-0 625 (historical)
+    /// - Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM
+    /// - IEC 61966-2-1 sYCC
+    /// - IEC 61966-2-4 xvYCC601
+    ///
+    /// (functionally the same as the value 6)
     BT470BG = 5,
+    /// - Rec. ITU-R BT.601-7 525
+    /// - Rec. ITU-R BT.1358-1 525 or 625 (historical)
+    /// - Rec. ITU-R BT.1700-0 NTSC
+    /// - SMPTE ST 170 (2004)
+    ///
+    /// (functionally the same as the value 5)
     ST170M = 6,
+    /// SMPTE ST 240 (1999)
     ST240M = 7,
+    /// The YCoCg color model, also known as the YCgCo color model,
+    /// is the color space formed from a simple transformation of
+    /// an associated RGB color space into a luma value and
+    /// two chroma values called chrominance green and chrominance orange.
     YCgCo = 8,
+    /// - Rec. ITU-R BT.2020-2 (non-constant luminance)
+    /// - Rec. ITU-R BT.2100-2 Y′CbCr
     BT2020NonConstantLuminance = 9,
+    /// Rec. ITU-R BT.2020-2 (constant luminance)
     BT2020ConstantLuminance = 10,
+    /// SMPTE ST 2085 (2015)
     ST2085 = 11,
+    /// Chromaticity-derived non-constant luminance system
     ChromaticityDerivedNonConstantLuminance = 12,
+    /// Chromaticity-derived constant luminance system
     ChromaticityDerivedConstantLuminance = 13,
+    /// Rec. ITU-R BT.2100-2 ICTCP
     ICtCp = 14,
 }
 
@@ -80,23 +125,64 @@ impl fmt::Display for MatrixCoefficients {
     }
 }
 
+/// indicates the chromaticity coordinates of the source colour primaries as specified in Table 2 in terms
+/// of the CIE 1931 definition of x and y as specified by ISO 11664-1.
+///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ColorPrimaries {
+    /// For future use by ITU-T | ISO/IEC
     Reserved0 = 0,
+    /// - Rec. ITU-R BT.709-6
+    /// - Rec. ITU-R BT.1361-0 conventional colour gamut
+    ///   system and extended colour gamut system (historical)
+    /// - IEC 61966-2-1 sRGB or sYCC
+    /// - IEC 61966-2-4
+    /// - Society of Motion Picture and Television Engineers
+    ///   (SMPTE) RP 177 (1993) Annex B
     BT709 = 1,
+    /// Image characteristics are unknown or are determined by
+    /// the application.
     Unspecified = 2,
+    /// For future use by ITU-T | ISO/IEC
     Reserved = 3,
+    /// - Rec. ITU-R BT.470-6 System M (historical)
+    /// - United States National Television System Committee
+    ///   1953 Recommendation for transmission standards for
+    ///   color television
+    /// - United States Federal Communications Commission
+    ///   (2003) Title 47 Code of Federal Regulations 73.682 (a) (20)
     BT470M = 4,
+    /// - Rec. ITU-R BT.470-6 System B, G (historical)
+    /// - Rec. ITU-R BT.601-7 625
+    /// - Rec. ITU-R BT.1358-0 625 (historical)
+    /// - Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM
     BT470BG = 5,
+    /// - Rec. ITU-R BT.601-7 525
+    /// - Rec. ITU-R BT.1358-1 525 or 625 (historical)
+    /// - Rec. ITU-R BT.1700-0 NTSC
+    /// - SMPTE ST 170 (2004)
+    ///
+    /// (functionally the same as the value 7)
     ST170M = 6,
+    /// - SMPTE ST 240 (1999)
+    ///
+    /// (functionally the same as the value 6)
     ST240M = 7,
+    /// Generic film (colour filters using Illuminant C)
     Film = 8,
+    /// - Rec. ITU-R BT.2020-2
+    /// - Rec. ITU-R BT.2100-2
     BT2020 = 9,
+    /// - SMPTE ST 428-1 (2019)
+    /// - (CIE 1931 XYZ as in ISO 11664-1)
     ST428 = 10,
+    /// SMPTE RP 431-2 (2011)
     P3DCI = 11,
+    /// SMPTE EG 432-1 (2010)
     P3Display = 12,
+    /// No corresponding industry specification identified
     Tech3213 = 22,
 }
 
@@ -121,28 +207,93 @@ impl fmt::Display for ColorPrimaries {
     }
 }
 
+/// either indicates the reference opto-electronic transfer characteristic
+/// function of the source picture as a function of a source input linear optical intensity
+/// input Lc with a nominal real-valued range of 0 to 1 or indicates the inverse of the
+/// reference electro-optical transfer characteristic function as a function of an
+/// output linear optical intensity Lo with a nominal real-valued range of 0 to 1.
+///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TransferCharacteristic {
+    /// For future use by ITU-T | ISO/IEC
     Reserved0 = 0,
+    /// - Rec. ITU-R BT.709-6
+    /// - Rec. ITU-R BT.1361-0 conventional
+    ///   colour gamut system (historical)
+    ///
+    /// (functionally the same as the values 6, 14 and 15)
     BT1886 = 1,
+    /// Image characteristics are unknown or
+    /// are determined by the application.
     Unspecified = 2,
+    /// For future use by ITU-T | ISO/IEC
     Reserved = 3,
+    /// Assumed display gamma 2.2
+    ///
+    /// - Rec. ITU-R BT.470-6 System M
+    ///   (historical)
+    /// - United States National Television
+    ///   System Committee 1953
+    ///   Recommendation for transmission
+    ///   standards for color television
+    /// - United States Federal Communications
+    ///   Commission (2003) Title 47 Code of
+    ///   Federal Regulations 73.682 (a) (20)
+    /// - Rec. ITU-R BT.1700-0 625 PAL and
+    ///   625 SECAM
     BT470M = 4,
+    /// Assumed display gamma 2.8
+    ///
+    /// Rec. ITU-R BT.470-6 System B, G (historical)
     BT470BG = 5,
+    /// - Rec. ITU-R BT.601-7 525 or 625
+    /// - Rec. ITU-R BT.1358-1 525 or 625
+    ///   (historical)
+    /// - Rec. ITU-R BT.1700-0 NTSC
+    /// - SMPTE ST 170 (2004)
+    ///
+    /// (functionally the same as the values 1, 14 and 15)
     ST170M = 6,
+    /// SMPTE ST 240 (1999)
     ST240M = 7,
+    /// Linear transfer characteristics
     Linear = 8,
+    /// Logarithmic transfer characteristic
+    /// (100:1 range)
     Logarithmic100 = 9,
+    /// Logarithmic transfer characteristic
+    /// (100 * Sqrt( 10 ) : 1 range)
     Logarithmic316 = 10,
+    /// IEC 61966-2-4
     XVYCC = 11,
+    /// Rec. ITU-R BT.1361-0 extended
+    /// colour gamut system (historical)
     BT1361E = 12,
+    /// - IEC 61966-2-1 sRGB (with
+    ///   MatrixCoefficients equal to 0)
+    /// - IEC 61966-2-1 sYCC (with
+    ///   MatrixCoefficients equal to 5)
     SRGB = 13,
+    /// Rec. ITU-R BT.2020-2 (10-bit system)
+    ///
+    /// (functionally the same as the values 1, 6 and 15)
     BT2020Ten = 14,
+    /// Rec. ITU-R BT.2020-2 (12-bit system)
+    ///
+    /// (functionally the same as the values 1, 6 and 14)
     BT2020Twelve = 15,
+    /// - SMPTE ST 2084 (2014) for 10-, 12-,
+    ///   14- and 16-bit systems
+    /// - Rec. ITU-R BT.2100-2 perceptual
+    ///   quantization (PQ) system
     PerceptualQuantizer = 16,
+    /// SMPTE ST 428-1 (2019)
     ST428 = 17,
+    /// - ARIB STD-B67 (2015)
+    /// - Rec. ITU-R BT.2100-2 hybrid log-
+    ///   gamma (HLG) system
     HybridLogGamma = 18,
 }
 
@@ -172,8 +323,13 @@ impl fmt::Display for TransferCharacteristic {
     }
 }
 
+/// indicates the chroma sampling grid alignment for video fields or frames using the 4:2:0
+/// colour format (in which the two chroma arrays have half the width
+/// and half the height of the associated luma array)
+///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum ChromaLocation {
     Unspecified = 0,
     Left,
@@ -203,8 +359,18 @@ impl fmt::Display for ChromaLocation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum YUVSystem {
+    /// YCbCr is a family of color spaces used as a part of the color image pipeline
+    /// in video and digital photography systems. Y′ is the luma component and CB and CR
+    /// are the blue-difference and red-difference chroma components.
     YCbCr(YUVRange),
+    /// The YCoCg color model, also known as the YCgCo color model,
+    /// is the color space formed from a simple transformation of
+    /// an associated RGB color space into a luma value and
+    /// two chroma values called chrominance green and chrominance orange.
     YCoCg,
+    /// ICtCp is a color representation format specified in the Rec. ITU-R BT.2100 standard
+    /// that is used as a part of the color image pipeline in video and digital photography
+    /// systems for high dynamic range (HDR) and wide color gamut (WCG) imagery.
     ICtCp,
 }
 
@@ -223,8 +389,14 @@ impl fmt::Display for YUVSystem {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TrichromaticEncodingSystem {
+    /// Image represented by three color channels: Red, Green, and Blue
     RGB,
+    /// Image represented by a luminance (luma) channel and two chroma channels.
     YUV(YUVSystem),
+    /// In the CIE 1931 model, Y is the luminance, Z is quasi-equal to blue (of CIE RGB),
+    /// and X is a mix of the three CIE RGB curves chosen to be nonnegative.
+    /// Setting Y as luminance has the useful result that for any given Y value,
+    /// the XZ plane will contain all possible chromaticities at that luminance.
     XYZ,
 }
 
@@ -243,9 +415,19 @@ impl fmt::Display for TrichromaticEncodingSystem {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ColorModel {
+    /// An image represented by three channels or planes: Includes RGB, YUV, and XYZ.
     Trichromatic(TrichromaticEncodingSystem),
+    /// The CMYK color model is a subtractive color model, based on the CMY color model,
+    /// used in color printing, and is also used to describe the printing process itself.
+    /// CMYK refers to the four ink plates used in some color printing: cyan, magenta, yellow, and key.
     CMYK,
+    /// HSL and HSV are alternative representations of the RGB color model,
+    /// designed in the 1970s by computer graphics researchers to more closely align
+    /// with the way human vision perceives color-making attributes.
     HSV,
+    /// The CIELAB color space expresses color as three values:
+    /// L* for perceptual lightness, and a* and b* for the four unique colors of human vision:
+    /// red, green, blue, and yellow.
     LAB,
 }
 

--- a/data/src/pixel.rs
+++ b/data/src/pixel.rs
@@ -46,13 +46,13 @@ pub enum MatrixCoefficients {
     Identity = 0,
     /// - Rec. ITU-R BT.709-6
     /// - Rec. ITU-R BT.1361-0 conventional colour gamut system and extended colour
-    /// - gamut system (historical)
+    ///   gamut system (historical)
     /// - IEC 61966-2-4 xvYCC709
     /// - SMPTE RP 177 (1993) Annex B
     BT709 = 1,
-    /// Image characteristics are unknown or are determined by the application
+    /// Image characteristics are unknown or are determined by the application.
     Unspecified = 2,
-    /// For future use by ITU-T | ISO/IEC
+    /// For future use by ITU-T | ISO/IEC.
     Reserved = 3,
     /// United States Federal Communications Commission (2003) Title 47 Code of
     /// Federal Regulations 73.682 (a) (20)
@@ -87,9 +87,9 @@ pub enum MatrixCoefficients {
     BT2020ConstantLuminance = 10,
     /// SMPTE ST 2085 (2015)
     ST2085 = 11,
-    /// Chromaticity-derived non-constant luminance system
+    /// Chromaticity-derived non-constant luminance system.
     ChromaticityDerivedNonConstantLuminance = 12,
-    /// Chromaticity-derived constant luminance system
+    /// Chromaticity-derived constant luminance system.
     ChromaticityDerivedConstantLuminance = 13,
     /// Rec. ITU-R BT.2100-2 ICTCP
     ICtCp = 14,
@@ -125,14 +125,14 @@ impl fmt::Display for MatrixCoefficients {
     }
 }
 
-/// indicates the chromaticity coordinates of the source colour primaries as specified in Table 2 in terms
+/// Indicates the chromaticity coordinates of the source colour primaries as specified in Table 2 in terms
 /// of the CIE 1931 definition of x and y as specified by ISO 11664-1.
 ///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ColorPrimaries {
-    /// For future use by ITU-T | ISO/IEC
+    /// For future use by ITU-T | ISO/IEC.
     Reserved0 = 0,
     /// - Rec. ITU-R BT.709-6
     /// - Rec. ITU-R BT.1361-0 conventional colour gamut
@@ -145,7 +145,7 @@ pub enum ColorPrimaries {
     /// Image characteristics are unknown or are determined by
     /// the application.
     Unspecified = 2,
-    /// For future use by ITU-T | ISO/IEC
+    /// For future use by ITU-T | ISO/IEC.
     Reserved = 3,
     /// - Rec. ITU-R BT.470-6 System M (historical)
     /// - United States National Television System Committee
@@ -182,7 +182,7 @@ pub enum ColorPrimaries {
     P3DCI = 11,
     /// SMPTE EG 432-1 (2010)
     P3Display = 12,
-    /// No corresponding industry specification identified
+    /// No corresponding industry specification identified.
     Tech3213 = 22,
 }
 
@@ -207,7 +207,7 @@ impl fmt::Display for ColorPrimaries {
     }
 }
 
-/// either indicates the reference opto-electronic transfer characteristic
+/// Either indicates the reference opto-electronic transfer characteristic
 /// function of the source picture as a function of a source input linear optical intensity
 /// input Lc with a nominal real-valued range of 0 to 1 or indicates the inverse of the
 /// reference electro-optical transfer characteristic function as a function of an
@@ -217,7 +217,7 @@ impl fmt::Display for ColorPrimaries {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TransferCharacteristic {
-    /// For future use by ITU-T | ISO/IEC
+    /// For future use by ITU-T | ISO/IEC.
     Reserved0 = 0,
     /// - Rec. ITU-R BT.709-6
     /// - Rec. ITU-R BT.1361-0 conventional
@@ -228,9 +228,9 @@ pub enum TransferCharacteristic {
     /// Image characteristics are unknown or
     /// are determined by the application.
     Unspecified = 2,
-    /// For future use by ITU-T | ISO/IEC
+    /// For future use by ITU-T | ISO/IEC.
     Reserved = 3,
-    /// Assumed display gamma 2.2
+    /// Assumed display gamma 2.2.
     ///
     /// - Rec. ITU-R BT.470-6 System M
     ///   (historical)
@@ -244,7 +244,7 @@ pub enum TransferCharacteristic {
     /// - Rec. ITU-R BT.1700-0 625 PAL and
     ///   625 SECAM
     BT470M = 4,
-    /// Assumed display gamma 2.8
+    /// Assumed display gamma 2.8.
     ///
     /// Rec. ITU-R BT.470-6 System B, G (historical)
     BT470BG = 5,
@@ -323,7 +323,7 @@ impl fmt::Display for TransferCharacteristic {
     }
 }
 
-/// indicates the chroma sampling grid alignment for video fields or frames using the 4:2:0
+/// Indicates the chroma sampling grid alignment for video fields or frames using the 4:2:0
 /// colour format (in which the two chroma arrays have half the width
 /// and half the height of the associated luma array)
 ///
@@ -389,7 +389,7 @@ impl fmt::Display for YUVSystem {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TrichromaticEncodingSystem {
-    /// Image represented by three color channels: Red, Green, and Blue
+    /// Image represented by three color channels: Red, Green, and Blue.
     RGB,
     /// Image represented by a luminance (luma) channel and two chroma channels.
     YUV(YUVSystem),

--- a/data/src/pixel.rs
+++ b/data/src/pixel.rs
@@ -1,10 +1,7 @@
-//!
 //! Expose all necessary data structures to represent pixels.
 //!
 //! Re-exports num_traits::FromPrimitive and num_traits::cast::ToPrimitive
 //! in order to make easy to cast a parsed value into correct enum structures.
-//!
-//!
 
 use num_derive::{FromPrimitive, ToPrimitive};
 pub use num_traits::cast::ToPrimitive;

--- a/data/src/timeinfo.rs
+++ b/data/src/timeinfo.rs
@@ -1,3 +1,5 @@
+//! Time info definitions for frames and packets.
+
 use crate::rational::Rational64;
 use std::any::Any;
 use std::sync::Arc;

--- a/data/src/value.rs
+++ b/data/src/value.rs
@@ -1,3 +1,5 @@
+//! Option values definitions.
+
 use crate::audiosample::Soniton;
 use crate::pixel::Formaton;
 

--- a/format/src/demuxer.rs
+++ b/format/src/demuxer.rs
@@ -184,6 +184,7 @@ pub struct Descr {
 
 /// Used to get a format descriptor and create a new demuxer.
 pub trait Descriptor {
+    /// The specific type of the demuxer.
     type OutputDemuxer: Demuxer;
 
     /// Creates a new demuxer for the requested format.

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,3 +1,5 @@
+//! Contains utilities for muxing and demuxing into various container formats.
+
 #![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
 
 mod data {
@@ -6,9 +8,15 @@ mod data {
 
 pub use av_data::rational;
 
+/// Buffered data helpers
 pub mod buffer;
+/// Common data structs reused between muxers and demuxers
 pub mod common;
+/// Utilities for demuxing containers
 pub mod demuxer;
+/// Error types
 pub mod error;
+/// Utilities for muxing containers
 pub mod muxer;
+/// Data structs representing a video, audio, or subtitle stream
 pub mod stream;

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
 
 mod data {
     pub use av_data::*;

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -8,15 +8,15 @@ mod data {
 
 pub use av_data::rational;
 
-/// Buffered data helpers
+/// Buffered data helpers.
 pub mod buffer;
-/// Common data structs reused between muxers and demuxers
+/// Common data structs reused between muxers and demuxers.
 pub mod common;
-/// Utilities for demuxing containers
+/// Utilities for demuxing containers.
 pub mod demuxer;
-/// Error types
+/// Error types.
 pub mod error;
-/// Utilities for muxing containers
+/// Utilities for muxing containers.
 pub mod muxer;
-/// Data structs representing a video, audio, or subtitle stream
+/// Data structs representing a video, audio, or subtitle stream.
 pub mod stream;

--- a/format/src/muxer.rs
+++ b/format/src/muxer.rs
@@ -7,10 +7,12 @@ use std::sync::Arc;
 
 use crate::error::*;
 
-/// Runtime wrapper around either a [`Write`] or a [`WriteSeek`] trait object
+/// Runtime wrapper around either a [`Write`] or a [`Write + Seek`] trait object
 /// which supports querying for seek support.
 pub enum Writer<WO = Cursor<Vec<u8>>, WS = Cursor<Vec<u8>>> {
+    /// A writer which does not support seeking, e.g. stdout.
     NonSeekable(WO, u64),
+    /// A writer which does support seeking, e.g. a file or in-memory buffer.
     Seekable(WS),
 }
 
@@ -223,6 +225,7 @@ pub struct Descr {
 
 /// Used to get a format descriptor and create a new muxer.
 pub trait Descriptor {
+    /// The specific type of the muxer.
     type OutputMuxer: Muxer + Send;
 
     /// Creates a new muxer for the requested format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,25 @@
-#![deny(clippy::undocumented_unsafe_blocks)]
+//! A collection of utilities for handling multimedia formats.
+//! The goal is to provide functionality similar to ffmpeg/libav,
+//! but written in pure Rust.
 
+#![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
+
+/// Contains utilities for encoding and decoding video and audio formats.
+pub mod codec {
+    pub use av_codec::*;
+}
+
+/// Structs and traits to interact with multimedia data.
 pub mod data {
     pub use av_data::*;
 }
 
+/// Contains utilities for muxing and demuxing into various container formats.
 pub mod format {
     pub use av_format::*;
 }
 
+/// Bytes and bitstream reading/writing functionality.
 pub mod bitstream {
     pub use av_bitstream::*;
 }


### PR DESCRIPTION
This enforces via the compiler that all public items are documented, and adds documentation for items that did not have it.