### PR TITLE
Use initialized data for a new frame 

### DIFF
--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.4.1
+
+- Use initialized data for a frame.
+
 ## Version 0.4.0
 
 - Upgrade to Rust edition 2021.

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "av-data"
 description = "Multimedia data structures"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 homepage = "https://github.com/rust-av/rust-av"

--- a/data/src/frame.rs
+++ b/data/src/frame.rs
@@ -402,7 +402,7 @@ impl DefaultFrameBuffer {
         match *kind {
             MediaKind::Video(ref video) => {
                 let size = video.size(ALIGNMENT);
-                let buf = BytesMut::with_capacity(size);
+                let buf = BytesMut::zeroed(size);
                 let mut buffer = DefaultFrameBuffer {
                     buf,
                     planes: Vec::with_capacity(video.format.get_num_comp()),
@@ -421,7 +421,7 @@ impl DefaultFrameBuffer {
             }
             MediaKind::Audio(ref audio) => {
                 let size = audio.size(ALIGNMENT);
-                let buf = BytesMut::with_capacity(size);
+                let buf = BytesMut::zeroed(size);
                 let mut buffer = DefaultFrameBuffer {
                     buf,
                     planes: if audio.format.planar {


### PR DESCRIPTION
Using `with_capacity` does not initialize any data, so when the `split_to` API is called, a panic is raised