### PR TITLE
Add benchmarks with criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,11 @@ path = "data"
 [dependencies.av-format]
 version = "0.7.0"
 path = "format"
+
+[dev-dependencies]
+criterion = "0.4.0"
+
+[[bench]]
+name = "bench"
+path = "benches/bench.rs"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,7 @@
+use criterion::{criterion_group, criterion_main};
+
+mod bitstream;
+mod format;
+
+criterion_group!(benches, format::bench_format, bitstream::bench_bitstream);
+criterion_main!(benches);

--- a/benches/bitstream.rs
+++ b/benches/bitstream.rs
@@ -1,0 +1,32 @@
+use av_bitstream::bitread::*;
+use criterion::{Criterion, Throughput};
+
+const TEST_INPUT: [u8; 16] = [0b01010101; 16];
+
+fn bitread(bytes: &[u8]) {
+    let mut reader = BitReadLE::new(bytes);
+
+    // Each iteration consumes 64-bits
+    while reader.available() > 0 {
+        reader.skip_bits(1);
+        reader.get_bits_32(1);
+        reader.skip_bits(3);
+        reader.get_bits_32(3);
+        reader.skip_bits(5);
+        reader.get_bits_32(5);
+        reader.skip_bits(7);
+        reader.get_bits_32(7);
+        reader.skip_bits(11);
+        reader.get_bits_32(11);
+
+        reader.peek_bits_32(10);
+        reader.skip_bits(10);
+    }
+}
+
+pub fn bench_bitstream(c: &mut Criterion) {
+    let mut group = c.benchmark_group("av_bitstream");
+    group.throughput(Throughput::Bytes(TEST_INPUT.len() as u64));
+    group.bench_function("BitRead", |b| b.iter(|| bitread(&TEST_INPUT)));
+    group.finish();
+}

--- a/benches/format.rs
+++ b/benches/format.rs
@@ -7,7 +7,7 @@ use criterion::{Criterion, Throughput};
 const TEST_INPUT: [u8; 16] = [0b01010101; 16];
 
 fn bench_accreader(bytes: &[u8]) {
-    let cursor = Cursor::new(&bytes[..]);
+    let cursor = Cursor::new(&bytes);
     let mut reader = AccReader::with_capacity(5, cursor);
     let mut read_buffer = [0];
 

--- a/benches/format.rs
+++ b/benches/format.rs
@@ -1,0 +1,24 @@
+use std::io::Cursor;
+use std::io::Read;
+
+use av_format::buffer::AccReader;
+use criterion::{Criterion, Throughput};
+
+const TEST_INPUT: [u8; 16] = [0b01010101; 16];
+
+fn bench_accreader(bytes: &[u8]) {
+    let cursor = Cursor::new(&bytes[..]);
+    let mut reader = AccReader::with_capacity(5, cursor);
+    let mut read_buffer = [0];
+
+    for _ in 0..bytes.len() {
+        reader.read_exact(&mut read_buffer).unwrap();
+    }
+}
+
+pub fn bench_format(c: &mut Criterion) {
+    let mut group = c.benchmark_group("av_format");
+    group.throughput(Throughput::Bytes(TEST_INPUT.len() as u64));
+    group.bench_function("AccReader", |b| b.iter(|| bench_accreader(&TEST_INPUT)));
+    group.finish();
+}


### PR DESCRIPTION
This PR adds benchmarks for the followings by utilizing [criterion](https://github.com/japaric/criterion.rs):

1. Bit reading operations with `BitReadLE`: `get_bits_32`, `peek_bits_32`, and `skip_bits`
2. Byte reading operations with `AccReader`: `read_exact` 

See: #36