### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/rust-av.yml
+++ b/.github/workflows/rust-av.yml
@@ -20,6 +20,7 @@ on:
 env:
   # CI doesn't benefit from incremental builds, this just increases cache size
   CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
 
   #
   # Dependency versioning
@@ -46,7 +47,7 @@ jobs:
 
     - name: Run clippy
       run: |
-        cargo clippy --workspace --all-features --all-targets -- -D warnings --verbose
+        cargo clippy --workspace --all-features --all-targets
 
   grcov-codecov:
 
@@ -71,10 +72,10 @@ jobs:
 
     - name: Run tests
       env:
-        RUSTFLAGS: "-Cinstrument-coverage"
+        RUSTFLAGS: "-Dwarnings -Cinstrument-coverage"
         LLVM_PROFILE_FILE: "rust-av-%p-%m.profraw"
       run: |
-        cargo test --workspace --verbose
+        cargo test --workspace
 
     - name: Get coverage data for codecov
       run: |
@@ -106,11 +107,11 @@ jobs:
 
     - name: Run tests
       run: |
-        cargo test --workspace --all-features --verbose
+        cargo test --workspace --all-features
 
     - name: Run doc
       run: |
-        cargo doc --workspace --all-features --verbose
+        cargo doc --workspace --all-features
 
   wasm-test:
 

--- a/.github/workflows/rust-av.yml
+++ b/.github/workflows/rust-av.yml
@@ -18,6 +18,9 @@ on:
       - '**.toml'
 
 env:
+  # CI doesn't benefit from incremental builds, this just increases cache size
+  CARGO_INCREMENTAL: 0
+
   #
   # Dependency versioning
   #
@@ -98,6 +101,8 @@ jobs:
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+
+    - uses: Swatinem/rust-cache@v2
 
     - name: Run tests
       run: |

--- a/.github/workflows/rust-av.yml
+++ b/.github/workflows/rust-av.yml
@@ -108,14 +108,9 @@ jobs:
       run: |
         cargo test --workspace --all-features --verbose
 
-    - name: Run bench
-      run: |
-        cargo bench --workspace --all-features --verbose
-
     - name: Run doc
       run: |
         cargo doc --workspace --all-features --verbose
-
 
   wasm-test:
 


### PR DESCRIPTION
- Add build caching for test job
- Remove bench step from test job: Benching on CI is unreliable because underlying hardware can vary wildly (we had a similar problem in the [ssimulacra2](https://github.com/rust-av/ssimulacra2/pull/7) crate before) 
- Remove `--verbose` flag: Seems unnecessary and clutters the UI when trying to skim the logs
- Use `-Dwarnings` everywhere: Good practice