### PR TITLE
data: Derive Hash impl for some types

### DIFF
--- a/bitstream/src/bytewrite.rs
+++ b/bitstream/src/bytewrite.rs
@@ -209,33 +209,35 @@ mod test {
             $(
                 paste::item! {
                     #[test]
+                    #[allow(clippy::float_equality_without_abs)]
                     fn [<put_and_get_ $TYPE _be>]() {
                         let item_size = size_of::<$TYPE>();
                         let mut buf = vec![0; 3 * item_size];
                         [<put_ $TYPE b>](&mut buf, 1 as $TYPE);
-                        assert!(1 as $TYPE - [<get_ $TYPE b>](&buf) < ::std::$TYPE::EPSILON);
+                        assert!(1 as $TYPE - [<get_ $TYPE b>](&buf) < $TYPE::EPSILON);
 
                         [<put_ $TYPE b>](&mut buf[(1 * item_size)..], 2 as $TYPE);
-                        assert!(2 as $TYPE - [<get_ $TYPE b>](&buf[(1 * item_size)..]) < ::std::$TYPE::EPSILON);
+                        assert!(2 as $TYPE - [<get_ $TYPE b>](&buf[(1 * item_size)..]) < $TYPE::EPSILON);
 
                         [<put_ $TYPE b>](&mut buf[(2 * item_size)..], 255 as $TYPE);
-                        assert!(255 as $TYPE - [<get_ $TYPE b>](&buf[(2 * item_size)..]) < ::std::$TYPE::EPSILON);
+                        assert!(255 as $TYPE - [<get_ $TYPE b>](&buf[(2 * item_size)..]) < $TYPE::EPSILON);
                     }
                 }
 
                 paste::item! {
                     #[test]
+                    #[allow(clippy::float_equality_without_abs)]
                     fn [<put_and_get_ $TYPE _l>]() {
                         let item_size = size_of::<$TYPE>();
                         let mut buf = vec![0; 3 * item_size];
                         [<put_ $TYPE l>](&mut buf, 1 as $TYPE);
-                        assert!(1 as $TYPE - [<get_ $TYPE l>](&buf) < ::std::$TYPE::EPSILON);
+                        assert!(1 as $TYPE - [<get_ $TYPE l>](&buf) < $TYPE::EPSILON);
 
                         [<put_ $TYPE l>](&mut buf[(1 * item_size)..], 2 as $TYPE);
-                        assert!(2 as $TYPE - [<get_ $TYPE l>](&buf[(1 * item_size)..]) < ::std::$TYPE::EPSILON);
+                        assert!(2 as $TYPE - [<get_ $TYPE l>](&buf[(1 * item_size)..]) < $TYPE::EPSILON);
 
                         [<put_ $TYPE l>](&mut buf[(2 * item_size)..], 255 as $TYPE);
-                        assert!(255 as $TYPE - [<get_ $TYPE l>](&buf[(2 * item_size)..]) < ::std::$TYPE::EPSILON);
+                        assert!(255 as $TYPE - [<get_ $TYPE l>](&buf[(2 * item_size)..]) < $TYPE::EPSILON);
                     }
                 }
             )*

--- a/data/src/audiosample.rs
+++ b/data/src/audiosample.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::string::*;
 
 /// Audio format definition.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Soniton {
     /// Bits per sample.
     pub bits: u8,
@@ -79,7 +79,7 @@ impl fmt::Display for Soniton {
 }
 
 /// Known audio channel types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ChannelType {
     /// Center front.

--- a/data/src/frame.rs
+++ b/data/src/frame.rs
@@ -18,7 +18,7 @@ use crate::timeinfo::*;
 use self::FrameError::*;
 
 /// Frame errors.
-#[derive(Debug, Error)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
 pub enum FrameError {
     /// Invalid frame index.
     #[error("Invalid Index")]
@@ -30,7 +30,7 @@ pub enum FrameError {
 
 // TODO: Change it to provide Droppable/Seekable information or use a separate enum?
 /// A list of recognized frame types.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum FrameType {
     /// Intra frame type.

--- a/data/src/pixel.rs
+++ b/data/src/pixel.rs
@@ -11,7 +11,7 @@ use std::ops::Index;
 use std::slice;
 
 /// YUV color range.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum YUVRange {
     /// Pixels in the range [16, 235].
@@ -34,7 +34,7 @@ impl fmt::Display for YUVRange {
 ///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, FromPrimitive, ToPrimitive)]
 pub enum MatrixCoefficients {
     /// The identity matrix.
     /// Typically used for:
@@ -129,7 +129,7 @@ impl fmt::Display for MatrixCoefficients {
 /// of the CIE 1931 definition of x and y as specified by ISO 11664-1.
 ///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, FromPrimitive, ToPrimitive)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ColorPrimaries {
     /// For future use by ITU-T | ISO/IEC.
@@ -214,7 +214,7 @@ impl fmt::Display for ColorPrimaries {
 /// output linear optical intensity Lo with a nominal real-valued range of 0 to 1.
 ///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, FromPrimitive, ToPrimitive)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TransferCharacteristic {
     /// For future use by ITU-T | ISO/IEC.
@@ -328,7 +328,7 @@ impl fmt::Display for TransferCharacteristic {
 /// and half the height of the associated luma array)
 ///
 /// Values adopted from Table 4 of ISO/IEC 23001-8:2013/DCOR1.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum ChromaLocation {
     Unspecified = 0,
@@ -356,7 +356,7 @@ impl fmt::Display for ChromaLocation {
 }
 
 /// All YUV color representations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum YUVSystem {
     /// YCbCr is a family of color spaces used as a part of the color image pipeline
@@ -386,7 +386,7 @@ impl fmt::Display for YUVSystem {
 }
 
 /// Trichromatic color encoding system.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TrichromaticEncodingSystem {
     /// Image represented by three color channels: Red, Green, and Blue.
@@ -412,7 +412,7 @@ impl fmt::Display for TrichromaticEncodingSystem {
 }
 
 /// All supported color models.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ColorModel {
     /// An image represented by three channels or planes: Includes RGB, YUV, and XYZ.
@@ -456,7 +456,7 @@ impl ColorModel {
 ///
 /// Defines how the components of a colorspace are subsampled and
 /// where and how they are stored.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Chromaton {
     /// Horizontal subsampling in power of two
     /// (e.g. `0` = no subsampling, `1` = only every second value is stored).
@@ -597,7 +597,7 @@ impl fmt::Display for Chromaton {
 ///
 /// For example, the format can be paletted, so the components describe
 /// the palette storage format, while the actual data is 8-bit palette indices.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub struct Formaton {
     /// Image color model.
     pub model: ColorModel,

--- a/format/src/demuxer.rs
+++ b/format/src/demuxer.rs
@@ -212,7 +212,7 @@ pub trait Probe<T: Descriptor + ?Sized> {
 
 impl<T: Descriptor + ?Sized> Probe<T> for [&'static T] {
     fn probe(&self, data: &[u8]) -> Option<&'static T> {
-        let mut max = u8::min_value();
+        let mut max = u8::MIN;
         let mut candidate: Option<&'static T> = None;
         for desc in self {
             let score = desc.probe(data);

--- a/src/io/byteread.rs
+++ b/src/io/byteread.rs
@@ -1,9 +1,11 @@
+// This has been written and tested, but has no specific usecase yet.
+#![allow(dead_code)]
+
 use std::io::ErrorKind::*;
 use std::io::{BufRead, Error, Read, Result};
 
 use crate::bitstream::byteread::*;
 
-#[allow(dead_code)]
 fn get_buffer<R: Read + ?Sized>(reader: &mut R, buf: &mut [u8]) -> Result<()> {
     let mut nread = 0usize;
     while nread < buf.len() {


### PR DESCRIPTION
Not much to say, this is a fundamental trait that can be helpful if you want to use a type in a `HashMap` or something similar. I didn't derive it for every trait in av-data because some have heap-allocated types and manual `PartialEq`/`Eq` implementations (`Hash` and `Eq` have a [special relation](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq) to one another).