### PR TITLE
data: Remove `thiserror` dependency

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 [dependencies]
 byte-slice-cast = "1.2.1"
 bytes = "1.2.1"
-thiserror = "1.0"
 num-rational = "0.4.0"
 num-traits = "0.2.8"
 num-derive = "0.4"

--- a/data/src/frame.rs
+++ b/data/src/frame.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 
 use byte_slice_cast::*;
 use bytes::BytesMut;
-use thiserror::Error;
 
 use crate::audiosample::*;
 use crate::pixel::*;
@@ -18,14 +17,23 @@ use crate::timeinfo::*;
 use self::FrameError::*;
 
 /// Frame errors.
-#[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum FrameError {
     /// Invalid frame index.
-    #[error("Invalid Index")]
     InvalidIndex,
     /// Invalid frame conversion.
-    #[error("Invalid Conversion")]
     InvalidConversion,
+}
+
+impl std::error::Error for FrameError {}
+
+impl fmt::Display for FrameError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            InvalidIndex => write!(f, "Invalid Index"),
+            InvalidConversion => write!(f, "Invalid Conversion"),
+        }
+    }
 }
 
 // TODO: Change it to provide Droppable/Seekable information or use a separate enum?


### PR DESCRIPTION
The `thiserror` change is trivial. I'm split on the `num_derive` replacement.

I've manually implemented `FromPrimitive`/`ToPrimitive` for enums with few variants that are unlikely to change. For those, it seems fine to just write the boiler plate. But for these larger enums, I wanted more robustness so I wrote a declarative macro. I'm confident that it works, but I'm not sure if this is code is nice enough to replace a `#[derive]`.

But, with this change:
```sh
$ cargo tree -p av-data -e normal | grep -c syn
0
```

Let me know what you think.