### PR TITLE
Remove thiserror dependency from all crates in this repository

### DIFF
--- a/bitstream/Cargo.toml
+++ b/bitstream/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/rust-av/rust-av"
 edition = "2021"
 
 [dependencies]
-thiserror = "1.0"
 num-traits = "0.2.8"
 
 [dev-dependencies]

--- a/bitstream/src/codebook.rs
+++ b/bitstream/src/codebook.rs
@@ -4,22 +4,31 @@
 
 use std::cmp::{max, min};
 use std::collections::HashMap;
+use std::fmt;
 use std::marker::PhantomData;
 
 use num_traits::AsPrimitive;
-use thiserror::Error;
 
 use crate::bitread::*;
 
 /// Codebook operations errors.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum CodebookError {
     /// The codebook is invalid.
-    #[error("Invalid Codebook")]
     InvalidCodebook,
     /// The analyzed bitstream is not present in the codebook.
-    #[error("Invalid Code")]
     InvalidCode,
+}
+
+impl std::error::Error for CodebookError {}
+
+impl fmt::Display for CodebookError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            InvalidCodebook => write!(f, "Invalid Codebook"),
+            InvalidCode => write!(f, "Invalid Code"),
+        }
+    }
 }
 
 use self::CodebookError::*;

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -9,5 +9,4 @@ edition = "2021"
 
 [dependencies]
 av-data = "0.4.0"
-thiserror = "1.0"
 num-rational = "0.4.0"

--- a/codec/src/error.rs
+++ b/codec/src/error.rs
@@ -1,25 +1,34 @@
-use thiserror::Error;
+use std::fmt;
 
 /// General coding errors.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum Error {
     /// Invalid input data.
-    #[error("Invalid Data")]
     InvalidData,
     /// A coding operation needs more data to be completed.
-    #[error("Additional data needed")]
     MoreDataNeeded,
     /// Incomplete input configuration.
-    #[error("Configuration Incomplete")]
     ConfigurationIncomplete,
     /// Invalid input configuration.
-    #[error("Configuration Invalid")]
     ConfigurationInvalid,
     /// Unsupported requested feature.
-    #[error("Unsupported feature {0}")]
     Unsupported(String),
     // TODO add support for dependency-specific errors here
     // Inner(failure::Context)
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidData => write!(f, "Invalid Data"),
+            Error::MoreDataNeeded => write!(f, "Additional data needed"),
+            Error::ConfigurationIncomplete => write!(f, "Configuration Incomplete"),
+            Error::ConfigurationInvalid => write!(f, "Configuration Invalid"),
+            Error::Unsupported(feat) => write!(f, "Unsupported feature {feat}"),
+        }
+    }
 }
 
 /// A specialized `Result` type for coding operations.

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/rust-av/rust-av"
 
 [dependencies]
 log = "0.4.6"
-thiserror = "1.0"
 av-data = "0.4.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/format/src/error.rs
+++ b/format/src/error.rs
@@ -1,19 +1,40 @@
+use std::fmt;
 use std::io;
 
-use thiserror::Error;
-
 /// General muxing/demuxing errors.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum Error {
     /// Invalid input data.
-    #[error("Invalid Data")]
     InvalidData,
     /// A muxing/demuxing operation needs more data to be completed.
-    #[error("{0} more bytes needed")]
     MoreDataNeeded(usize),
-    #[error("I/O error")]
     /// A more generic I/O error.
-    Io(#[from] io::Error),
+    Io(io::Error),
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidData => write!(f, "Invalid Data"),
+            Error::MoreDataNeeded(n) => write!(f, "{n} more bytes needed"),
+            Error::Io(_) => write!(f, "I/O error"),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
 }
 
 /// A specialized `Result` type for muxing/demuxing operations.


### PR DESCRIPTION
Related to #193. I don't think adding `thiserror` for these simple error types is necessary, and `thiserror` recently updated to v2.0 (see #196). I have a feeling this will cause some fragmentation over time (some older crates depend on 1, while newer crates update to 2) and entirely removing `thiserror` alleviates that problem for dependent crates.