### PR TITLE
add explicit lifetime for iterator

### DIFF
--- a/data/src/pixel.rs
+++ b/data/src/pixel.rs
@@ -793,7 +793,7 @@ impl Formaton {
     }
 
     /// Returns an iterator over the format definition of each component.
-    pub fn iter(&self) -> slice::Iter<Option<Chromaton>> {
+    pub fn iter(&'_ self) -> slice::Iter<'_, Option<Chromaton>> {
         self.comp_info.iter()
     }
 }


### PR DESCRIPTION
Attempt to fix failing CI checks.

I'm not sure its more readable, but seems better than a suppression.